### PR TITLE
DEC-1110: Create media

### DIFF
--- a/app/controllers/media_files_controller.rb
+++ b/app/controllers/media_files_controller.rb
@@ -2,7 +2,8 @@ class MediaFilesController < ApplicationController
   def create
     media = CreateMediaFile.call(params: save_params)
     if media.valid?
-      render json: SerializeMediaFile.to_json(object: media)
+      render json: SerializeCompletedCreateAction.to_json(object: media, object_serializer: SerializeMediaFile),
+             status: :success
     else
       render json: SerializeFailedCreateAction.to_json(object: media, object_serializer: SerializeMediaFile),
              status: :unprocessable_entity

--- a/app/services/serialize_completed_create_action.rb
+++ b/app/services/serialize_completed_create_action.rb
@@ -1,0 +1,10 @@
+class SerializeCompletedCreateAction
+  def self.to_json(object:, object_serializer:)
+    "{
+      \"@context\": \"http://schema.org\",
+      \"@type\": \"CreateAction\",
+      \"actionStatus\": \"CompletedActionStatus\",
+      \"object\": #{object_serializer.to_json(object: object)}
+    }"
+  end
+end

--- a/app/services/serialize_completed_create_action.rb
+++ b/app/services/serialize_completed_create_action.rb
@@ -1,10 +1,14 @@
 class SerializeCompletedCreateAction
+  def self.to_hash(object:, object_serializer:)
+    {
+      "@context": "http://schema.org",
+      "@type": "CreateAction",
+      "actionStatus": "CompletedActionStatus",
+      "object": object_serializer.to_hash(object: object)
+    }
+  end
+
   def self.to_json(object:, object_serializer:)
-    "{
-      \"@context\": \"http://schema.org\",
-      \"@type\": \"CreateAction\",
-      \"actionStatus\": \"CompletedActionStatus\",
-      \"object\": #{object_serializer.to_json(object: object)}
-    }"
+    to_hash(object: object, object_serializer: object_serializer).to_json
   end
 end

--- a/app/services/serialize_failed_create_action.rb
+++ b/app/services/serialize_failed_create_action.rb
@@ -1,5 +1,5 @@
 class SerializeFailedCreateAction
-  def self.to_json(object:, object_serializer:)
+  def self.to_hash(object:, object_serializer:)
     errors = object.errors.map do |k, v|
       {
         "name": k,
@@ -7,12 +7,16 @@ class SerializeFailedCreateAction
       }
     end
 
-    "{
-      \"@context\": \"http://schema.org\",
-      \"@type\": \"CreateAction\",
-      \"actionStatus\": \"FailedActionStatus\",
-      \"object\": #{object_serializer.to_json(object: object)},
-      \"error\": #{errors.to_json}
-    }"
+    {
+      "@context": "http://schema.org",
+      "@type": "CreateAction",
+      "actionStatus": "FailedActionStatus",
+      "object": object_serializer.to_hash(object: object),
+      "error": errors
+    }
+  end
+
+  def self.to_json(object:, object_serializer:)
+    to_hash(object: object, object_serializer: object_serializer).to_json
   end
 end

--- a/app/services/serialize_media_file.rb
+++ b/app/services/serialize_media_file.rb
@@ -3,7 +3,11 @@ class SerializeMediaFile
     MediaFile.new(hash)
   end
 
+  def self.to_hash(object:)
+    object.attributes.except("id")
+  end
+
   def self.to_json(object:)
-    object.to_json(except: :id)
+    to_hash(object: object).to_json
   end
 end

--- a/config/database_example.yml
+++ b/config/database_example.yml
@@ -1,0 +1,24 @@
+pg_settings: &pg_settings
+  adapter: postgresql
+  encoding: utf8
+  reconnect: true
+  pool: 5
+
+local_user: &local_user
+  username: root
+  password:
+
+development:
+  <<: *local_user
+  <<: *pg_settings
+  host:     localhost
+  database: buzz_development
+
+# Warning: The database defined as "test" will be erased and
+# re-generated from your development database when you run "rake".
+# Do not set this db to the same as development or production.
+test:
+  <<: *local_user
+  <<: *pg_settings
+  host:     localhost
+  database: buzz_test

--- a/spec/controllers/media_files_controller_spec.rb
+++ b/spec/controllers/media_files_controller_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe MediaFilesController, type: :controller do
-  let(:media) { instance_double(MediaFile, "uuid=": true, valid?: true, errors: "validation errors") }
+  let(:media) { instance_double(MediaFile, attributes: {}, "uuid=": true, valid?: true, errors: "validation errors") }
 
   before(:each) do
     allow(MediaFile).to receive(:new).and_return(media)

--- a/spec/controllers/media_files_controller_spec.rb
+++ b/spec/controllers/media_files_controller_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe MediaFilesController, type: :controller do
       subject
     end
 
-    it "uses SerializeMediaFile to render the json" do
-      expect(SerializeMediaFile).to receive(:to_json).with(object: media)
+    it "uses SerializeCompletedCreateAction to render the json" do
+      expect(SerializeCompletedCreateAction).to receive(:to_json).with(object: media, object_serializer: SerializeMediaFile)
       subject
     end
 

--- a/spec/services/serialize_completed_create_action_spec.rb
+++ b/spec/services/serialize_completed_create_action_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+describe SerializeCompletedCreateAction do
+  let(:object_serializer) { double(Object, to_json: "\"json from object_serializer\"") }
+  let(:object) { double(Object, errors: { "field": "error" }) }
+  let(:subject) { JSON.parse(SerializeCompletedCreateAction.to_json(object: object, object_serializer: object_serializer)) }
+
+  it "renders the correct context" do
+    expect(subject).to include("@context" => "http://schema.org")
+  end
+
+  it "renders the correct type" do
+    expect(subject).to include("@type" => "CreateAction")
+  end
+
+  it "renders the correct status" do
+    expect(subject).to include("actionStatus" => "CompletedActionStatus")
+  end
+
+  it "renders the object as json using the object serializer" do
+    expect(subject).to include("object" => "json from object_serializer")
+  end
+end

--- a/spec/services/serialize_completed_create_action_spec.rb
+++ b/spec/services/serialize_completed_create_action_spec.rb
@@ -1,23 +1,51 @@
 require "rails_helper"
 
 describe SerializeCompletedCreateAction do
-  let(:object_serializer) { double(Object, to_json: "\"json from object_serializer\"") }
+  let(:object_serializer) { double(Object, to_hash: "json from object_serializer") }
   let(:object) { double(Object, errors: { "field": "error" }) }
-  let(:subject) { JSON.parse(SerializeCompletedCreateAction.to_json(object: object, object_serializer: object_serializer)) }
 
-  it "renders the correct context" do
-    expect(subject).to include("@context" => "http://schema.org")
+
+  describe "to_hash" do
+    let(:subject) { SerializeCompletedCreateAction.to_hash(object: object, object_serializer: object_serializer) }
+
+    it "renders the correct context" do
+      expect(subject).to include("@context": "http://schema.org")
+    end
+
+    it "renders the correct type" do
+      expect(subject).to include("@type": "CreateAction")
+    end
+
+    it "renders the correct status" do
+      expect(subject).to include(actionStatus: "CompletedActionStatus")
+    end
+
+    it "renders the object as json using the object serializer" do
+      expect(subject).to include(object: "json from object_serializer")
+    end
   end
 
-  it "renders the correct type" do
-    expect(subject).to include("@type" => "CreateAction")
-  end
+  describe "to_json" do
+    let(:subject) { JSON.parse(SerializeCompletedCreateAction.to_json(object: object, object_serializer: object_serializer)) }
 
-  it "renders the correct status" do
-    expect(subject).to include("actionStatus" => "CompletedActionStatus")
-  end
+    it "can be parsed as a json" do
+      expect{ subject }.not_to raise_error
+    end
 
-  it "renders the object as json using the object serializer" do
-    expect(subject).to include("object" => "json from object_serializer")
+    it "renders the correct context" do
+      expect(subject).to include("@context" => "http://schema.org")
+    end
+
+    it "renders the correct type" do
+      expect(subject).to include("@type" => "CreateAction")
+    end
+
+    it "renders the correct status" do
+      expect(subject).to include("actionStatus" => "CompletedActionStatus")
+    end
+
+    it "renders the object as json using the object serializer" do
+      expect(subject).to include("object" => "json from object_serializer")
+    end
   end
 end

--- a/spec/services/serialize_failed_create_action_spec.rb
+++ b/spec/services/serialize_failed_create_action_spec.rb
@@ -1,27 +1,54 @@
 require "rails_helper"
 
 describe SerializeFailedCreateAction do
-  let(:object_serializer) { double(Object, to_json: "\"json from object_serializer\"") }
-  let(:object) { double(Object, errors: { "field": "error" }) }
-  let(:subject) { JSON.parse(SerializeFailedCreateAction.to_json(object: object, object_serializer: object_serializer)) }
+  let(:object_serializer) { double(Object, to_hash: "json from object_serializer") }
+  let(:object) { double(Object, errors: { "field" => "error" }) }
 
-  it "renders the correct context" do
-    expect(subject).to include("@context" => "http://schema.org")
+  describe "to_hash" do
+    let(:subject) { SerializeFailedCreateAction.to_hash(object: object, object_serializer: object_serializer) }
+
+    it "renders the correct context" do
+      expect(subject).to include("@context": "http://schema.org")
+    end
+
+    it "renders the correct type" do
+      expect(subject).to include("@type": "CreateAction")
+    end
+
+    it "renders the correct status" do
+      expect(subject).to include(actionStatus: "FailedActionStatus")
+    end
+
+    it "renders any errors attached to the object" do
+      expect(subject).to include(error: [{name: "field", description: "error"}])
+    end
+
+    it "renders the object as json using the object serializer" do
+      expect(subject).to include(object: "json from object_serializer")
+    end
   end
 
-  it "renders the correct type" do
-    expect(subject).to include("@type" => "CreateAction")
-  end
+  describe "to_json" do
+    let(:subject) { JSON.parse(SerializeFailedCreateAction.to_json(object: object, object_serializer: object_serializer)) }
 
-  it "renders the correct status" do
-    expect(subject).to include("actionStatus" => "FailedActionStatus")
-  end
+    it "renders the correct context" do
+      expect(subject).to include("@context" => "http://schema.org")
+    end
 
-  it "renders any errors attached to the object" do
-    expect(subject).to include("error" => [{"name"=>"field", "description"=>"error"}])
-  end
+    it "renders the correct type" do
+      expect(subject).to include("@type" => "CreateAction")
+    end
 
-  it "renders the object as json using the object serializer" do
-    expect(subject).to include("object" => "json from object_serializer")
+    it "renders the correct status" do
+      expect(subject).to include("actionStatus" => "FailedActionStatus")
+    end
+
+    it "renders any errors attached to the object" do
+      expect(subject).to include("error" => [{"name"=>"field", "description"=>"error"}])
+    end
+
+    it "renders the object as json using the object serializer" do
+      expect(subject).to include("object" => "json from object_serializer")
+    end
   end
 end

--- a/spec/services/serialize_media_file_spec.rb
+++ b/spec/services/serialize_media_file_spec.rb
@@ -20,13 +20,27 @@ describe SerializeMediaFile do
     end
   end
 
-  describe "to_json" do
+  describe "to_hash" do
+    let(:subject) { SerializeMediaFile.to_hash(object: media) }
+
     it "excludes id" do
-      expect(JSON.parse(SerializeMediaFile.to_json(object: media), symbolize_names: true)).not_to include(:"id")
+      expect(subject).not_to include(:"id")
     end
 
     it "includes all other attributes" do
-      expect(JSON.parse(SerializeMediaFile.to_json(object: media), symbolize_names: true)).to include(:"uuid", :"file_path", :"media_type")
+      expect(subject).to include("uuid", "file_path", "media_type")
+    end
+  end
+
+  describe "to_json" do
+    let(:subject) { JSON.parse(SerializeMediaFile.to_json(object: media), symbolize_names: true) }
+
+    it "excludes id" do
+      expect(subject).not_to include(:"id")
+    end
+
+    it "includes all other attributes" do
+      expect(subject).to include(:"uuid", :"file_path", :"media_type")
     end
   end
 end


### PR DESCRIPTION
Changing the response of a successful create to render an Action object as well, ex:
```
{
    "@context": "http://schema.org",
    "@type": "CreateAction",
    "actionStatus": "CompletedActionStatus",
    "object": {
        "media_type": "video",
        "file_path": "big_full.mov",
        "uuid": "08fd17d7-b886-4569-a191-e3fbc27ab85e"
    }
}
```

Also re-added an example database config.