### PR TITLE
DEC-1113: Update MediaFile

### DIFF
--- a/app/controllers/media_files_controller.rb
+++ b/app/controllers/media_files_controller.rb
@@ -1,9 +1,9 @@
 class MediaFilesController < ApplicationController
   def create
-    media = CreateMediaFile.call(params: save_params)
+    media = CreateMediaFile.call(params: create_params)
     if media.valid?
       render json: SerializeCompletedCreateAction.to_json(object: media, object_serializer: SerializeMediaFile),
-             status: :success
+             status: :ok
     else
       render json: SerializeFailedCreateAction.to_json(object: media, object_serializer: SerializeMediaFile),
              status: :unprocessable_entity
@@ -11,6 +11,14 @@ class MediaFilesController < ApplicationController
   end
 
   def update
+    media = QueryMediaFile.find(uuid: params[:id])
+    if UpdateMediaFile.call(media: media, params: update_params)
+      render json: SerializeCompletedUpdateAction.to_json(object: media, object_serializer: SerializeMediaFile),
+             status: :ok
+    else
+      render json: SerializeFailedUpdateAction.to_json(object: media, object_serializer: SerializeMediaFile),
+             status: :unprocessable_entity
+    end
   end
 
   def destroy
@@ -18,7 +26,11 @@ class MediaFilesController < ApplicationController
 
   protected
 
-  def save_params
+  def create_params
     params.require(:media_file).permit(:file_path, :media_type)
+  end
+
+  def update_params
+    params.require(:media_file).permit()
   end
 end

--- a/app/queries/query_media_file.rb
+++ b/app/queries/query_media_file.rb
@@ -1,0 +1,5 @@
+class QueryMediaFile
+  def self.find(uuid:)
+    MediaFile.where(uuid: uuid).take!
+  end
+end

--- a/app/services/serialize_completed_update_action.rb
+++ b/app/services/serialize_completed_update_action.rb
@@ -1,0 +1,14 @@
+class SerializeCompletedUpdateAction
+  def self.to_hash(object:, object_serializer:)
+    {
+      "@context": "http://schema.org",
+      "@type": "UpdateAction",
+      "actionStatus": "CompletedActionStatus",
+      "object": object_serializer.to_hash(object: object)
+    }
+  end
+
+  def self.to_json(object:, object_serializer:)
+    to_hash(object: object, object_serializer: object_serializer).to_json
+  end
+end

--- a/app/services/serialize_failed_update_action.rb
+++ b/app/services/serialize_failed_update_action.rb
@@ -1,0 +1,22 @@
+class SerializeFailedUpdateAction
+  def self.to_hash(object:, object_serializer:)
+    errors = object.errors.map do |k, v|
+      {
+        "name": k,
+        "description": v
+      }
+    end
+
+    {
+      "@context": "http://schema.org",
+      "@type": "UpdateAction",
+      "actionStatus": "FailedActionStatus",
+      "object": object_serializer.to_hash(object: object),
+      "error": errors
+    }
+  end
+
+  def self.to_json(object:, object_serializer:)
+    to_hash(object: object, object_serializer: object_serializer).to_json
+  end
+end

--- a/app/services/update_media_file.rb
+++ b/app/services/update_media_file.rb
@@ -1,0 +1,17 @@
+class UpdateMediaFile
+  attr_reader :media, :params
+
+  def self.call(media:, params:)
+    new(media: media, params: params).update!
+  end
+
+  def initialize(media:, params:)
+    @media = media
+    @params = params
+  end
+
+  def update!
+    media.attributes = params
+    media.save
+  end
+end

--- a/spec/controllers/media_files_controller_spec.rb
+++ b/spec/controllers/media_files_controller_spec.rb
@@ -1,25 +1,65 @@
 require "rails_helper"
 
 RSpec.describe MediaFilesController, type: :controller do
-  let(:media) { instance_double(MediaFile, attributes: {}, "uuid=": true, valid?: true, errors: "validation errors") }
-
-  before(:each) do
-    allow(MediaFile).to receive(:new).and_return(media)
-    allow(media).to receive(:save).and_return(true)
-  end
-
   describe "create" do
     let(:subject) { post :create, params: params }
     let(:params) { { media_file: { file_path: "file path", media_type: "media type" } } }
+    let(:media) { instance_double(MediaFile, attributes: {}, valid?: true) }
+
+    it "throws an exception if the media_file parameter is missing" do
+      params.delete(:media_file)
+      expect{ subject }.to raise_error(ActionController::ParameterMissing)
+    end
 
     it "uses the CreateMediaFile service" do
       expect(CreateMediaFile).to receive(:call).and_return(media)
       subject
     end
 
-    it "uses SerializeCompletedCreateAction to render the json" do
-      expect(SerializeCompletedCreateAction).to receive(:to_json).with(object: media, object_serializer: SerializeMediaFile)
-      subject
+    context "when media is valid" do
+      let(:media) { instance_double(MediaFile, attributes: {}, "uuid=": true, save: true, valid?: true) }
+
+      before(:each) do
+        allow(MediaFile).to receive(:new).and_return(media)
+      end
+
+      it "renders 200" do
+        subject
+        expect(response.status).to eq(200)
+      end
+
+      it "uses SerializeCompletedCreateAction to render the json" do
+        expect(SerializeCompletedCreateAction).to receive(:to_json).with(object: media, object_serializer: SerializeMediaFile)
+        subject
+      end
+    end
+
+    context "when media is invalid" do
+      let(:media) { instance_double(MediaFile, attributes: {}, "uuid=": true, save: false, valid?: false, errors: ["validation errors"]) }
+
+      before(:each) do
+        allow(MediaFile).to receive(:new).and_return(media)
+      end
+
+      it "renders 422 when given invalid parameters" do
+        subject
+        expect(response.status).to eq(422)
+      end
+
+      it "uses SerializeFailedCreateAction to render the json" do
+        expect(SerializeFailedCreateAction).to receive(:to_json).with(object: media, object_serializer: SerializeMediaFile)
+        subject
+      end
+    end
+  end
+
+  describe "update" do
+    let(:subject) { put :update, params: params }
+    let(:params) { { id: "1", media_file: { file_path: "file path", media_type: "media type" } } }
+    let(:media) { instance_double(MediaFile, attributes: {}, "attributes=": true, valid?: true, save: true) }
+
+    before(:each) do
+      allow(QueryMediaFile).to receive(:find).with(uuid: params[:id]).and_return(media)
     end
 
     it "throws an exception if the media_file parameter is missing" do
@@ -27,10 +67,45 @@ RSpec.describe MediaFilesController, type: :controller do
       expect{ subject }.to raise_error(ActionController::ParameterMissing)
     end
 
-    it "renders errors if the media is invalid" do
-      allow(media).to receive(:valid?).and_return(false)
-      expect(SerializeFailedCreateAction).to receive(:to_json).with(object: media, object_serializer: SerializeMediaFile)
+    it "uses the UpdateMediaFile service" do
+      expect(UpdateMediaFile).to receive(:call).and_return(media)
       subject
+    end
+
+    context "when media is valid" do
+      let(:media) { instance_double(MediaFile, attributes: {}, "attributes=": true, "uuid=": true, save: true, valid?: true) }
+
+      before(:each) do
+        allow(QueryMediaFile).to receive(:find).with(uuid: params[:id]).and_return(media)
+      end
+
+      it "renders 200" do
+        subject
+        expect(response.status).to eq(200)
+      end
+
+      it "uses SerializeCompletedUpdateAction to render the json" do
+        expect(SerializeCompletedUpdateAction).to receive(:to_json).with(object: media, object_serializer: SerializeMediaFile)
+        subject
+      end
+    end
+
+    context "when media is invalid" do
+      let(:media) { instance_double(MediaFile, attributes: {}, "attributes=": true, "uuid=": true, save: false, valid?: false, errors: ["validation errors"]) }
+
+      before(:each) do
+        allow(QueryMediaFile).to receive(:find).with(uuid: params[:id]).and_return(media)
+      end
+
+      it "renders 422 when given invalid parameters" do
+        subject
+        expect(response.status).to eq(422)
+      end
+
+      it "uses SerializeFailedUpdateAction to render the json" do
+        expect(SerializeFailedUpdateAction).to receive(:to_json).with(object: media, object_serializer: SerializeMediaFile)
+        subject
+      end
     end
   end
 end

--- a/spec/services/query_media_file_spec.rb
+++ b/spec/services/query_media_file_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+describe QueryMediaFile do
+  let(:media) { MediaFile.new(uuid: "87ea8e9c-5932-478e-95d8-aeb04888a89a", file_path: "file path", media_type: "media type") }
+
+  before(:each) do
+    media.save
+  end
+
+  describe "find" do
+    it "finds the correct record by uuid" do
+      expect(QueryMediaFile.find(uuid: "87ea8e9c-5932-478e-95d8-aeb04888a89a")).to eq(media)
+    end
+
+    it "throws an ActiveRecord::RecordNotFound exception if not found, so that controllers will 404" do
+      expect{ QueryMediaFile.find(uuid: 2) }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+end

--- a/spec/services/serialize_completed_update_action_spec.rb
+++ b/spec/services/serialize_completed_update_action_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+
+describe SerializeCompletedUpdateAction do
+  let(:object_serializer) { double(Object, to_hash: "json from object_serializer") }
+  let(:object) { double(Object, errors: { "field": "error" }) }
+
+
+  describe "to_hash" do
+    let(:subject) { SerializeCompletedUpdateAction.to_hash(object: object, object_serializer: object_serializer) }
+
+    it "renders the correct context" do
+      expect(subject).to include("@context": "http://schema.org")
+    end
+
+    it "renders the correct type" do
+      expect(subject).to include("@type": "UpdateAction")
+    end
+
+    it "renders the correct status" do
+      expect(subject).to include(actionStatus: "CompletedActionStatus")
+    end
+
+    it "renders the object as json using the object serializer" do
+      expect(subject).to include(object: "json from object_serializer")
+    end
+  end
+
+  describe "to_json" do
+    let(:subject) { JSON.parse(SerializeCompletedUpdateAction.to_json(object: object, object_serializer: object_serializer)) }
+
+    it "can be parsed as a json" do
+      expect{ subject }.not_to raise_error
+    end
+
+    it "renders the correct context" do
+      expect(subject).to include("@context" => "http://schema.org")
+    end
+
+    it "renders the correct type" do
+      expect(subject).to include("@type" => "UpdateAction")
+    end
+
+    it "renders the correct status" do
+      expect(subject).to include("actionStatus" => "CompletedActionStatus")
+    end
+
+    it "renders the object as json using the object serializer" do
+      expect(subject).to include("object" => "json from object_serializer")
+    end
+  end
+end

--- a/spec/services/serialize_failed_update_action_spec.rb
+++ b/spec/services/serialize_failed_update_action_spec.rb
@@ -1,0 +1,54 @@
+require "rails_helper"
+
+describe SerializeFailedUpdateAction do
+  let(:object_serializer) { double(Object, to_hash: "json from object_serializer") }
+  let(:object) { double(Object, errors: { "field" => "error" }) }
+
+  describe "to_hash" do
+    let(:subject) { SerializeFailedUpdateAction.to_hash(object: object, object_serializer: object_serializer) }
+
+    it "renders the correct context" do
+      expect(subject).to include("@context": "http://schema.org")
+    end
+
+    it "renders the correct type" do
+      expect(subject).to include("@type": "UpdateAction")
+    end
+
+    it "renders the correct status" do
+      expect(subject).to include(actionStatus: "FailedActionStatus")
+    end
+
+    it "renders any errors attached to the object" do
+      expect(subject).to include(error: [{name: "field", description: "error"}])
+    end
+
+    it "renders the object as json using the object serializer" do
+      expect(subject).to include(object: "json from object_serializer")
+    end
+  end
+
+  describe "to_json" do
+    let(:subject) { JSON.parse(SerializeFailedUpdateAction.to_json(object: object, object_serializer: object_serializer)) }
+
+    it "renders the correct context" do
+      expect(subject).to include("@context" => "http://schema.org")
+    end
+
+    it "renders the correct type" do
+      expect(subject).to include("@type" => "UpdateAction")
+    end
+
+    it "renders the correct status" do
+      expect(subject).to include("actionStatus" => "FailedActionStatus")
+    end
+
+    it "renders any errors attached to the object" do
+      expect(subject).to include("error" => [{"name"=>"field", "description"=>"error"}])
+    end
+
+    it "renders the object as json using the object serializer" do
+      expect(subject).to include("object" => "json from object_serializer")
+    end
+  end
+end

--- a/spec/services/update_media_file_spec.rb
+++ b/spec/services/update_media_file_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+describe UpdateMediaFile do
+  let(:params) { { media_type: "media type" } }
+  let(:media) { instance_double(MediaFile, "attributes=": true) }
+  let(:subject) { UpdateMediaFile.call(media: media, params: params) }
+
+  it "returns true when save succeeds" do
+    allow(media).to receive(:save).and_return(true)
+    expect(subject).to eq(true)
+  end
+
+  it "returns false when save fails" do
+    allow(media).to receive(:save).and_return(false)
+    expect(subject).to eq(false)
+  end
+end


### PR DESCRIPTION
Added the necessary routing, controller, and service classes for updating a MediaFile. For the moment, we are not allowing updating of file_path and media_type properties, so really this is only setting us up with objects we can iterate on later. At the moment it's not very useful.