### PR TITLE
DEC-1142 Fix guard by turning off spring

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,11 +21,9 @@ group :development, :test do
   # Call "byebug" anywhere in the code to stop execution and get a debugger console
   gem "byebug", platform: :mri
   gem "rspec-rails"
-  gem "spring-commands-rspec"
   gem "guard"
   gem "guard-rails"
   gem "guard-rspec"
-  gem "guard-spring"
 
   gem "rubocop"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,10 +96,6 @@ GEM
       guard (~> 2.1)
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
-    guard-spring (1.1.1)
-      guard (~> 2.0)
-      guard-compat (~> 1.1)
-      spring
     i18n (0.7.0)
     json (2.0.1)
     listen (3.1.5)
@@ -206,9 +202,6 @@ GEM
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
     slop (3.6.0)
-    spring (1.7.2)
-    spring-commands-rspec (1.0.4)
-      spring (>= 0.9.1)
     sprockets (3.6.3)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -241,7 +234,6 @@ DEPENDENCIES
   guard
   guard-rails
   guard-rspec
-  guard-spring
   hesburgh_infrastructure!
   newrelic_rpm
   pg
@@ -249,7 +241,6 @@ DEPENDENCIES
   rails (~> 5.0.0)
   rspec-rails
   rubocop
-  spring-commands-rspec
   tzinfo-data
 
 BUNDLED WITH

--- a/Guardfile
+++ b/Guardfile
@@ -5,9 +5,9 @@ hesburgh_guard = HesburghInfrastructure::Guard.new(:buzz, self)
 
 # Spring used for preloading application
 # https://github.com/guard/guard-spring
-hesburgh_guard.spring do
-  # Watch any custom paths
-end
+# hesburgh_guard.spring do
+#   # Watch any custom paths
+# end
 
 hesburgh_guard.rails do
   # Watch any custom paths


### PR DESCRIPTION
In order to stop Spring from reloading with every change to application files, prior to Guard running specs, I'm turning off Spring in development. The expected behavior running under Guard is that Spring will restart with every file change. There's no discernible way to stop that from happening, so the easiest solution is to just remove Spring.