### PR TITLE
DEC-1145 Add Zeus as replacement for Spring

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ group :development, :test do
   gem "guard"
   gem "guard-rails"
   gem "guard-rspec"
+  gem "guard-zeus"
 
   gem "rubocop"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,6 +96,10 @@ GEM
       guard (~> 2.1)
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
+    guard-zeus (2.0.1)
+      guard (~> 2.0)
+      guard-compat (~> 1.1)
+      zeus (~> 0)
     i18n (0.7.0)
     json (2.0.1)
     listen (3.1.5)
@@ -223,6 +227,8 @@ GEM
     websocket-driver (0.6.4)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
+    zeus (0.15.4)
+      method_source (>= 0.6.7)
 
 PLATFORMS
   ruby
@@ -234,6 +240,7 @@ DEPENDENCIES
   guard
   guard-rails
   guard-rspec
+  guard-zeus
   hesburgh_infrastructure!
   newrelic_rpm
   pg

--- a/Guardfile
+++ b/Guardfile
@@ -22,27 +22,78 @@ end
 #  * zeus: 'zeus rspec' (requires the server to be started separately)
 #  * 'just' rspec: 'rspec'
 
-guard :rspec, cmd: "bundle exec rspec" do
-  require "guard/rspec/dsl"
-  dsl = Guard::RSpec::Dsl.new(self)
+# guard :rspec, cmd: "bundle exec rspec" do
+#   require "guard/rspec/dsl"
+#   dsl = Guard::RSpec::Dsl.new(self)
+#
+#   # Feel free to open issues for suggestions and improvements
+#
+#   # RSpec files
+#   rspec = dsl.rspec
+#   watch(rspec.spec_helper) { rspec.spec_dir }
+#   watch(rspec.spec_support) { rspec.spec_dir }
+#   watch(rspec.spec_files)
+#
+#   # Ruby files
+#   ruby = dsl.ruby
+#   dsl.watch_spec_files_for(ruby.lib_files)
+#
+#   # Rails files
+#   rails = dsl.rails(view_extensions: %w(erb haml slim))
+#   dsl.watch_spec_files_for(rails.app_files)
+#   dsl.watch_spec_files_for(rails.views)
+#
+#   watch(rails.controllers) do |m|
+#     [
+#       rspec.spec.call("routing/#{m[1]}_routing"),
+#       rspec.spec.call("controllers/#{m[1]}_controller"),
+#       rspec.spec.call("acceptance/#{m[1]}")
+#     ]
+#   end
+#
+#   # Rails config changes
+#   watch(rails.spec_helper)     { rspec.spec_dir }
+#   watch(rails.routes)          { "#{rspec.spec_dir}/routing" }
+#   watch(rails.app_controller)  { "#{rspec.spec_dir}/controllers" }
+#
+#   # Capybara features specs
+#   watch(rails.view_dirs)     { |m| rspec.spec.call("features/#{m[1]}") }
+#   watch(rails.layouts)       { |m| rspec.spec.call("features/#{m[1]}") }
+#
+#   # Turnip features and steps
+#   watch(%r{^spec/acceptance/(.+)\.feature$})
+#   watch(%r{^spec/acceptance/steps/(.+)_steps\.rb$}) do |m|
+#     Dir[File.join("**/#{m[1]}.feature")][0] || "spec/acceptance"
+#   end
+# end
 
-  # Feel free to open issues for suggestions and improvements
+guard 'zeus', test_unit: false, run_all: true, cli: '> /dev/null' do
+  require 'ostruct'
 
-  # RSpec files
-  rspec = dsl.rspec
-  watch(rspec.spec_helper) { rspec.spec_dir }
-  watch(rspec.spec_support) { rspec.spec_dir }
+  rspec = OpenStruct.new
+  rspec.spec_dir = 'spec'
+  rspec.spec = ->(m) { "#{rspec.spec_dir}/#{m}_spec.rb" }
+  rspec.spec_helper = "#{rspec.spec_dir}/spec_helper.rb"
+
+  # matchers
+  rspec.spec_files = /^#{rspec.spec_dir}\/.+_spec\.rb$/
+
+  # Ruby apps
+  ruby = OpenStruct.new
+  ruby.lib_files = /^(lib\/.+)\.rb$/
+
   watch(rspec.spec_files)
+  watch(rspec.spec_helper) { rspec.spec_dir }
+  watch(ruby.lib_files) { |m| rspec.spec.call(m[1]) }
 
-  # Ruby files
-  ruby = dsl.ruby
-  dsl.watch_spec_files_for(ruby.lib_files)
+  # Rails example
+  rails = OpenStruct.new
+  rails.app_files = /^app\/(.+)\.rb$/
+  rails.views_n_layouts = /^app\/(.+(?:\.erb|\.haml|\.slim))$/
+  rails.controllers = %r{^app/controllers/(.+)_controller\.rb$}
 
-  # Rails files
-  rails = dsl.rails(view_extensions: %w(erb haml slim))
-  dsl.watch_spec_files_for(rails.app_files)
-  dsl.watch_spec_files_for(rails.views)
-
+  watch(rails.app_files) { |m| rspec.spec.call(m[1]) }
+  watch(rails.views_n_layouts) { |m| rspec.spec.call(m[1]) }
   watch(rails.controllers) do |m|
     [
       rspec.spec.call("routing/#{m[1]}_routing"),
@@ -51,18 +102,10 @@ guard :rspec, cmd: "bundle exec rspec" do
     ]
   end
 
-  # Rails config changes
-  watch(rails.spec_helper)     { rspec.spec_dir }
-  watch(rails.routes)          { "#{rspec.spec_dir}/routing" }
-  watch(rails.app_controller)  { "#{rspec.spec_dir}/controllers" }
-
-  # Capybara features specs
-  watch(rails.view_dirs)     { |m| rspec.spec.call("features/#{m[1]}") }
-  watch(rails.layouts)       { |m| rspec.spec.call("features/#{m[1]}") }
-
-  # Turnip features and steps
-  watch(%r{^spec/acceptance/(.+)\.feature$})
-  watch(%r{^spec/acceptance/steps/(.+)_steps\.rb$}) do |m|
-    Dir[File.join("**/#{m[1]}.feature")][0] || "spec/acceptance"
-  end
+  # TestUnit
+  # watch(%r|^test/(.*)_test\.rb$|)
+  # watch(%r|^lib/(.*)([^/]+)\.rb$|)     { |m| "test/#{m[1]}test_#{m[2]}.rb" }
+  # watch(%r|^test/test_helper\.rb$|)    { "test" }
+  # watch(%r|^app/controllers/(.*)\.rb$|) { |m| "test/functional/#{m[1]}_test.rb" }
+  # watch(%r|^app/models/(.*)\.rb$|)      { |m| "test/unit/#{m[1]}_test.rb" }
 end

--- a/Guardfile
+++ b/Guardfile
@@ -3,12 +3,6 @@ require "hesburgh_infrastructure"
 # New applications must be added to config/applications.yml in hesburgh_infrastructure
 hesburgh_guard = HesburghInfrastructure::Guard.new(:buzz, self)
 
-# Spring used for preloading application
-# https://github.com/guard/guard-spring
-# hesburgh_guard.spring do
-#   # Watch any custom paths
-# end
-
 hesburgh_guard.rails do
   # Watch any custom paths
 end
@@ -21,51 +15,6 @@ end
 #                          installed the spring binstubs per the docs)
 #  * zeus: 'zeus rspec' (requires the server to be started separately)
 #  * 'just' rspec: 'rspec'
-
-# guard :rspec, cmd: "bundle exec rspec" do
-#   require "guard/rspec/dsl"
-#   dsl = Guard::RSpec::Dsl.new(self)
-#
-#   # Feel free to open issues for suggestions and improvements
-#
-#   # RSpec files
-#   rspec = dsl.rspec
-#   watch(rspec.spec_helper) { rspec.spec_dir }
-#   watch(rspec.spec_support) { rspec.spec_dir }
-#   watch(rspec.spec_files)
-#
-#   # Ruby files
-#   ruby = dsl.ruby
-#   dsl.watch_spec_files_for(ruby.lib_files)
-#
-#   # Rails files
-#   rails = dsl.rails(view_extensions: %w(erb haml slim))
-#   dsl.watch_spec_files_for(rails.app_files)
-#   dsl.watch_spec_files_for(rails.views)
-#
-#   watch(rails.controllers) do |m|
-#     [
-#       rspec.spec.call("routing/#{m[1]}_routing"),
-#       rspec.spec.call("controllers/#{m[1]}_controller"),
-#       rspec.spec.call("acceptance/#{m[1]}")
-#     ]
-#   end
-#
-#   # Rails config changes
-#   watch(rails.spec_helper)     { rspec.spec_dir }
-#   watch(rails.routes)          { "#{rspec.spec_dir}/routing" }
-#   watch(rails.app_controller)  { "#{rspec.spec_dir}/controllers" }
-#
-#   # Capybara features specs
-#   watch(rails.view_dirs)     { |m| rspec.spec.call("features/#{m[1]}") }
-#   watch(rails.layouts)       { |m| rspec.spec.call("features/#{m[1]}") }
-#
-#   # Turnip features and steps
-#   watch(%r{^spec/acceptance/(.+)\.feature$})
-#   watch(%r{^spec/acceptance/steps/(.+)_steps\.rb$}) do |m|
-#     Dir[File.join("**/#{m[1]}.feature")][0] || "spec/acceptance"
-#   end
-# end
 
 guard 'zeus', test_unit: false, run_all: true, cli: '> /dev/null' do
   require 'ostruct'
@@ -101,11 +50,4 @@ guard 'zeus', test_unit: false, run_all: true, cli: '> /dev/null' do
       rspec.spec.call("acceptance/#{m[1]}")
     ]
   end
-
-  # TestUnit
-  # watch(%r|^test/(.*)_test\.rb$|)
-  # watch(%r|^lib/(.*)([^/]+)\.rb$|)     { |m| "test/#{m[1]}test_#{m[2]}.rb" }
-  # watch(%r|^test/test_helper\.rb$|)    { "test" }
-  # watch(%r|^app/controllers/(.*)\.rb$|) { |m| "test/functional/#{m[1]}_test.rb" }
-  # watch(%r|^app/models/(.*)\.rb$|)      { |m| "test/unit/#{m[1]}_test.rb" }
 end


### PR DESCRIPTION
Zeus is a drop in replacement for Spring but is much faster and has many more features we can use. To take full advantage of zeus, make sure you have the gem installed in your common gems location for the version of ruby you're running. If you use something like RVM, and you install application specific gems into vendor/bundle, run `gem install zeus` in the appropriate environment.

Zeus docs: https://github.com/burke/zeus

You can also run `zeus commands` which lists all of the rails associated commands you can run. (e.g. `zeus generate migration XYZ` instead of `rails generate migration XYZ` when you have guard running in another terminal). Zeus will use the instantiated instance you have running under Guard instead of having to fire up the entire rails application just to generate a migration.