### PR TITLE
DEC-1143: Render media file

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -33,8 +33,8 @@ Style/SymbolArray:
 
 # Most readable form.
 Style/AlignHash:
-  EnforcedHashRocketStyle: table
-  EnforcedColonStyle: table
+  EnforcedHashRocketStyle: key
+  EnforcedColonStyle: key
 
 # Mixing the styles looks just silly.
 Style/HashSyntax:
@@ -134,4 +134,7 @@ Lint/Debugger:
 
 # Style preference
 Style/MethodDefParentheses:
+  Enabled: false
+
+Style/FrozenStringLiteralComment:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ group :development, :test do
   # Call "byebug" anywhere in the code to stop execution and get a debugger console
   gem "byebug", platform: :mri
   gem "rspec-rails"
+  gem "rspec-collection_matchers"
   gem "guard"
   gem "guard-rails"
   gem "guard-rspec"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -170,6 +170,8 @@ GEM
       rspec-core (~> 3.5.0)
       rspec-expectations (~> 3.5.0)
       rspec-mocks (~> 3.5.0)
+    rspec-collection_matchers (1.1.2)
+      rspec-expectations (>= 2.99.0.beta1)
     rspec-core (3.5.1)
       rspec-support (~> 3.5.0)
     rspec-expectations (3.5.0)
@@ -239,6 +241,7 @@ DEPENDENCIES
   pg
   puma (~> 3.0)
   rails (~> 5.0.0)
+  rspec-collection_matchers
   rspec-rails
   rubocop
   tzinfo-data

--- a/app/controllers/media_files_controller.rb
+++ b/app/controllers/media_files_controller.rb
@@ -21,6 +21,12 @@ class MediaFilesController < ApplicationController
     end
   end
 
+  def show
+    media = QueryMediaFile.find(uuid: params[:id])
+    render json: SerializeMediaFile.to_json(object: media),
+           status: :ok
+  end
+
   def destroy
   end
 

--- a/app/models/media_file.rb
+++ b/app/models/media_file.rb
@@ -1,3 +1,4 @@
 class MediaFile < ActiveRecord::Base
-  validates :file_path, :media_type, :uuid, presence: true
+  validates :file_path, :uuid, presence: true
+  validates_inclusion_of :media_type, in: %w( video audio ), message: "'%{value}' is not valid"
 end

--- a/app/services/create_buzz_url.rb
+++ b/app/services/create_buzz_url.rb
@@ -1,0 +1,5 @@
+class CreateBuzzUrl
+  def self.call(uri)
+    "https://#{Rails.application.routes.default_url_options[:host]}:#{Rails.application.routes.default_url_options[:port]}/#{uri}"
+  end
+end

--- a/app/services/create_buzz_url.rb
+++ b/app/services/create_buzz_url.rb
@@ -1,5 +1,11 @@
 class CreateBuzzUrl
-  def self.call(uri)
-    "https://#{Rails.application.routes.default_url_options[:host]}:#{Rails.application.routes.default_url_options[:port]}/#{uri}"
+  def self.call(uri = nil)
+    host = Rails.application.routes.default_url_options[:host]
+    port = Rails.application.routes.default_url_options[:port]
+
+    port_suffix = ":#{port}" if port.present?
+    uri_suffix = "/#{uri}" if uri.present?
+
+    "https://#{host}#{port_suffix}#{uri_suffix}"
   end
 end

--- a/app/services/create_content_url.rb
+++ b/app/services/create_content_url.rb
@@ -1,0 +1,29 @@
+class CreateContentUrl
+  def self.http(object:)
+    "http://#{settings["host"]}:#{settings["port"]}" \
+          "/#{settings["application"]}/#{settings["instance"]}" \
+          "/#{prefix(object:object)}:#{settings["cache_source_prefix"]}/#{settings["cache_source"]}" \
+          "/#{object.file_path}/playlist.m3u8"
+  end
+
+  def self.rtmp(object:)
+    "rtmp://#{settings["host"]}:#{settings["port"]}" \
+          "/#{settings["application"]}/#{settings["instance"]}" \
+          "/#{prefix(object:object)}:#{settings["cache_source_prefix"]}/#{settings["cache_source"]}" \
+          "/#{object.file_path}"
+  end
+
+  private
+
+  def self.prefix(object:)
+    if object.media_type.downcase == "video"
+      "mp4"
+    else
+      "mp3"
+    end
+  end
+
+  def self.settings
+    settings ||= Rails.configuration.settings.wowza
+  end
+end

--- a/app/services/serialize_audio_file.rb
+++ b/app/services/serialize_audio_file.rb
@@ -1,0 +1,23 @@
+class SerializeAudioFile
+  def self.to_hash(object:)
+    {
+      "@context": "http://schema.org",
+      "@type": "AudioObject",
+      "@id": object.uuid,
+      "description": object.file_path,
+      "name": object.file_path,
+      "thumbnailUrl": CreateBuzzUrl.call("audio.jpg"),
+      "uploadDate": object.updated_at,
+      "embedUrl": CreateBuzzUrl.call("?id=#{object.uuid}"),
+      "contentUrl": [
+        CreateContentUrl.http(object: object),
+        CreateContentUrl.rtmp(object: object),
+      ],
+      "url": Rails.application.routes.url_helpers.media_file_url(object.uuid)
+    }
+  end
+
+  def self.to_json(object:)
+    to_hash(object: object).to_json
+  end
+end

--- a/app/services/serialize_media_file.rb
+++ b/app/services/serialize_media_file.rb
@@ -4,7 +4,15 @@ class SerializeMediaFile
   end
 
   def self.to_hash(object:)
-    object.attributes.except("id")
+    type = object.media_type.present? ? object.media_type.downcase : ""
+    case type
+    when "video"
+      SerializeVideoFile.to_hash(object: object)
+    when "audio"
+      SerializeAudioFile.to_hash(object: object)
+    else
+      SerializeUnknownTypeFile.to_hash(object: object)
+    end
   end
 
   def self.to_json(object:)

--- a/app/services/serialize_unknown_type_file.rb
+++ b/app/services/serialize_unknown_type_file.rb
@@ -1,0 +1,9 @@
+class SerializeUnknownTypeFile
+  def self.to_hash(object:)
+    object.attributes.except("id", "uuid", "created_at", "updated_at")
+  end
+
+  def self.to_json(object:)
+    to_hash(object: object).to_json
+  end
+end

--- a/app/services/serialize_video_file.rb
+++ b/app/services/serialize_video_file.rb
@@ -1,0 +1,23 @@
+class SerializeVideoFile
+  def self.to_hash(object:)
+    {
+      "@context": "http://schema.org",
+      "@type": "VideoObject",
+      "@id": object.uuid,
+      "description": object.file_path,
+      "name": object.file_path,
+      "thumbnailUrl": CreateBuzzUrl.call("video.jpg"),
+      "uploadDate": object.updated_at,
+      "embedUrl": CreateBuzzUrl.call("?id=#{object.uuid}"),
+      "contentUrl": [
+        CreateContentUrl.http(object: object),
+        CreateContentUrl.rtmp(object: object),
+      ],
+      "url": Rails.application.routes.url_helpers.media_file_url(object.uuid)
+    }
+  end
+
+  def self.to_json(object:)
+    to_hash(object: object).to_json
+  end
+end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -44,4 +44,10 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+
+  Rails.application.routes.default_url_options = {
+    host: "localhost",
+    port: 3023,
+  }
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -75,4 +75,9 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  Rails.application.routes.default_url_options = {
+    host: "buzz.library.nd.edu",
+    protocol: "https"
+  }
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -39,4 +39,8 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  Rails.application.routes.default_url_options = {
+    host: "test.host",
+  }
 end

--- a/config/initializers/application_settings.rb
+++ b/config/initializers/application_settings.rb
@@ -1,0 +1,9 @@
+# Loads non-sensitive application configuration from config/settings.yml and makes it available from Rails.configuration.settings
+Rails.application.configure do
+  config_data = YAML.load_file(Rails.root.join("config", "settings.yml"))
+
+  config.settings = ActiveSupport::OrderedOptions.new
+  config_data[Rails.env].each do |key, value|
+    config.settings[key] = value
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   scope "v1" do
-    resources :media_files, only: [:create, :update, :destroy]
+    resources :media_files, only: [:create, :show, :update, :destroy]
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,0 +1,28 @@
+# Store non-sensitive configuration settings here.  Acessible from Rails.configuration.settings
+defaults: &defaults
+  wowza:
+    host: wowza.library.nd.edu
+    port: 1935
+    application: buzz_wow
+    instance: _definst_
+    cache_source_prefix: amazons3
+    cache_source: buzz-bucket.library.nd.edu
+
+
+local: &local
+  <<: *defaults
+
+deploy: &deploy
+  <<: *defaults
+
+development:
+  <<: *local
+
+test:
+  <<: *local
+
+pre_production:
+  <<: *deploy
+
+production:
+  <<: *deploy

--- a/db/migrate/20160713133918_add_timestamps_to_media_file.rb
+++ b/db/migrate/20160713133918_add_timestamps_to_media_file.rb
@@ -1,0 +1,6 @@
+class AddTimestampsToMediaFile < ActiveRecord::Migration[5.0]
+  def change
+      add_column(:media_files, :created_at, :datetime)
+      add_column(:media_files, :updated_at, :datetime)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,15 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160707201728) do
+ActiveRecord::Schema.define(version: 20160713133918) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "media_files", force: :cascade do |t|
-    t.string "media_type", null: false
-    t.string "file_path",  null: false
-    t.uuid   "uuid",       null: false
+    t.string   "media_type", null: false
+    t.string   "file_path",  null: false
+    t.uuid     "uuid",       null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
 end

--- a/spec/controllers/media_files_controller_spec.rb
+++ b/spec/controllers/media_files_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe MediaFilesController, type: :controller do
   describe "create" do
     let(:subject) { post :create, params: params }
     let(:params) { { media_file: { file_path: "file path", media_type: "media type" } } }
-    let(:media) { instance_double(MediaFile, attributes: {}, valid?: true) }
+    let(:media) { instance_double(MediaFile, media_type: "media type", attributes: {}, valid?: true) }
 
     it "throws an exception if the media_file parameter is missing" do
       params.delete(:media_file)
@@ -17,7 +17,7 @@ RSpec.describe MediaFilesController, type: :controller do
     end
 
     context "when media is valid" do
-      let(:media) { instance_double(MediaFile, attributes: {}, "uuid=": true, save: true, valid?: true) }
+      let(:media) { instance_double(MediaFile, media_type: "media type", attributes: {}, "uuid=": true, save: true, valid?: true) }
 
       before(:each) do
         allow(MediaFile).to receive(:new).and_return(media)
@@ -35,7 +35,7 @@ RSpec.describe MediaFilesController, type: :controller do
     end
 
     context "when media is invalid" do
-      let(:media) { instance_double(MediaFile, attributes: {}, "uuid=": true, save: false, valid?: false, errors: ["validation errors"]) }
+      let(:media) { instance_double(MediaFile, media_type: "media type", attributes: {}, "uuid=": true, save: false, valid?: false, errors: ["validation errors"]) }
 
       before(:each) do
         allow(MediaFile).to receive(:new).and_return(media)
@@ -56,7 +56,7 @@ RSpec.describe MediaFilesController, type: :controller do
   describe "update" do
     let(:subject) { put :update, params: params }
     let(:params) { { id: "1", media_file: { file_path: "file path", media_type: "media type" } } }
-    let(:media) { instance_double(MediaFile, attributes: {}, "attributes=": true, valid?: true, save: true) }
+    let(:media) { instance_double(MediaFile, media_type: "media type", attributes: {}, "attributes=": true, valid?: true, save: true) }
 
     before(:each) do
       allow(QueryMediaFile).to receive(:find).with(uuid: params[:id]).and_return(media)
@@ -73,7 +73,7 @@ RSpec.describe MediaFilesController, type: :controller do
     end
 
     context "when media is valid" do
-      let(:media) { instance_double(MediaFile, attributes: {}, "attributes=": true, "uuid=": true, save: true, valid?: true) }
+      let(:media) { instance_double(MediaFile, media_type: "media type", attributes: {}, "attributes=": true, "uuid=": true, save: true, valid?: true) }
 
       before(:each) do
         allow(QueryMediaFile).to receive(:find).with(uuid: params[:id]).and_return(media)
@@ -91,7 +91,7 @@ RSpec.describe MediaFilesController, type: :controller do
     end
 
     context "when media is invalid" do
-      let(:media) { instance_double(MediaFile, attributes: {}, "attributes=": true, "uuid=": true, save: false, valid?: false, errors: ["validation errors"]) }
+      let(:media) { instance_double(MediaFile, media_type: "media type", attributes: {}, "attributes=": true, "uuid=": true, save: false, valid?: false, errors: ["validation errors"]) }
 
       before(:each) do
         allow(QueryMediaFile).to receive(:find).with(uuid: params[:id]).and_return(media)
@@ -106,6 +106,17 @@ RSpec.describe MediaFilesController, type: :controller do
         expect(SerializeFailedUpdateAction).to receive(:to_json).with(object: media, object_serializer: SerializeMediaFile)
         subject
       end
+    end
+  end
+
+  describe "show" do
+    let(:subject) { get :show, params: params }
+    let(:params) { { id: "1" } }
+    let(:media) { instance_double(MediaFile, media_type: "media type", attributes: {}, "attributes=": true, valid?: true, save: true) }
+
+    it "uses QueryMediaFile to find the object" do
+      expect(QueryMediaFile).to receive(:find).with(uuid: params[:id]).and_return(media)
+      subject
     end
   end
 end

--- a/spec/controllers/media_files_controller_spec.rb
+++ b/spec/controllers/media_files_controller_spec.rb
@@ -3,12 +3,12 @@ require "rails_helper"
 RSpec.describe MediaFilesController, type: :controller do
   describe "create" do
     let(:subject) { post :create, params: params }
-    let(:params) { { media_file: { file_path: "file path", media_type: "media type" } } }
+    let(:params) { {media_file: {file_path: "file path", media_type: "media type"}} }
     let(:media) { instance_double(MediaFile, media_type: "media type", attributes: {}, valid?: true) }
 
     it "throws an exception if the media_file parameter is missing" do
       params.delete(:media_file)
-      expect{ subject }.to raise_error(ActionController::ParameterMissing)
+      expect { subject }.to raise_error(ActionController::ParameterMissing)
     end
 
     it "uses the CreateMediaFile service" do
@@ -17,7 +17,14 @@ RSpec.describe MediaFilesController, type: :controller do
     end
 
     context "when media is valid" do
-      let(:media) { instance_double(MediaFile, media_type: "media type", attributes: {}, "uuid=": true, save: true, valid?: true) }
+      let(:media) do
+        instance_double(MediaFile,
+                        media_type: "media type",
+                        attributes: {},
+                        "uuid=": true,
+                        save: true,
+                        valid?: true)
+      end
 
       before(:each) do
         allow(MediaFile).to receive(:new).and_return(media)
@@ -29,13 +36,22 @@ RSpec.describe MediaFilesController, type: :controller do
       end
 
       it "uses SerializeCompletedCreateAction to render the json" do
-        expect(SerializeCompletedCreateAction).to receive(:to_json).with(object: media, object_serializer: SerializeMediaFile)
+        expect(SerializeCompletedCreateAction).to receive(:to_json)
+          .with(object: media, object_serializer: SerializeMediaFile)
         subject
       end
     end
 
     context "when media is invalid" do
-      let(:media) { instance_double(MediaFile, media_type: "media type", attributes: {}, "uuid=": true, save: false, valid?: false, errors: ["validation errors"]) }
+      let(:media) do
+        instance_double(MediaFile,
+                        media_type: "media type",
+                        attributes: {},
+                        "uuid=": true,
+                        save: false,
+                        valid?: false,
+                        errors: ["validation errors"])
+      end
 
       before(:each) do
         allow(MediaFile).to receive(:new).and_return(media)
@@ -47,7 +63,8 @@ RSpec.describe MediaFilesController, type: :controller do
       end
 
       it "uses SerializeFailedCreateAction to render the json" do
-        expect(SerializeFailedCreateAction).to receive(:to_json).with(object: media, object_serializer: SerializeMediaFile)
+        expect(SerializeFailedCreateAction).to receive(:to_json)
+          .with(object: media, object_serializer: SerializeMediaFile)
         subject
       end
     end
@@ -55,8 +72,15 @@ RSpec.describe MediaFilesController, type: :controller do
 
   describe "update" do
     let(:subject) { put :update, params: params }
-    let(:params) { { id: "1", media_file: { file_path: "file path", media_type: "media type" } } }
-    let(:media) { instance_double(MediaFile, media_type: "media type", attributes: {}, "attributes=": true, valid?: true, save: true) }
+    let(:params) { {id: "1", media_file: {file_path: "file path", media_type: "media type"}} }
+    let(:media) do
+      instance_double(MediaFile,
+                      media_type: "media type",
+                      attributes: {},
+                      "attributes=": true,
+                      valid?: true,
+                      save: true)
+    end
 
     before(:each) do
       allow(QueryMediaFile).to receive(:find).with(uuid: params[:id]).and_return(media)
@@ -64,7 +88,7 @@ RSpec.describe MediaFilesController, type: :controller do
 
     it "throws an exception if the media_file parameter is missing" do
       params.delete(:media_file)
-      expect{ subject }.to raise_error(ActionController::ParameterMissing)
+      expect { subject }.to raise_error(ActionController::ParameterMissing)
     end
 
     it "uses the UpdateMediaFile service" do
@@ -73,7 +97,15 @@ RSpec.describe MediaFilesController, type: :controller do
     end
 
     context "when media is valid" do
-      let(:media) { instance_double(MediaFile, media_type: "media type", attributes: {}, "attributes=": true, "uuid=": true, save: true, valid?: true) }
+      let(:media) do
+        instance_double(MediaFile,
+                        media_type: "media type",
+                        attributes: {},
+                        "attributes=": true,
+                        "uuid=": true,
+                        save: true,
+                        valid?: true)
+      end
 
       before(:each) do
         allow(QueryMediaFile).to receive(:find).with(uuid: params[:id]).and_return(media)
@@ -85,13 +117,23 @@ RSpec.describe MediaFilesController, type: :controller do
       end
 
       it "uses SerializeCompletedUpdateAction to render the json" do
-        expect(SerializeCompletedUpdateAction).to receive(:to_json).with(object: media, object_serializer: SerializeMediaFile)
+        expect(SerializeCompletedUpdateAction).to receive(:to_json)
+          .with(object: media, object_serializer: SerializeMediaFile)
         subject
       end
     end
 
     context "when media is invalid" do
-      let(:media) { instance_double(MediaFile, media_type: "media type", attributes: {}, "attributes=": true, "uuid=": true, save: false, valid?: false, errors: ["validation errors"]) }
+      let(:media) do
+        instance_double(MediaFile,
+                        media_type: "media type",
+                        attributes: {},
+                        "attributes=": true,
+                        "uuid=": true,
+                        save: false,
+                        valid?: false,
+                        errors: ["validation errors"])
+      end
 
       before(:each) do
         allow(QueryMediaFile).to receive(:find).with(uuid: params[:id]).and_return(media)
@@ -103,7 +145,8 @@ RSpec.describe MediaFilesController, type: :controller do
       end
 
       it "uses SerializeFailedUpdateAction to render the json" do
-        expect(SerializeFailedUpdateAction).to receive(:to_json).with(object: media, object_serializer: SerializeMediaFile)
+        expect(SerializeFailedUpdateAction).to receive(:to_json)
+          .with(object: media, object_serializer: SerializeMediaFile)
         subject
       end
     end
@@ -111,8 +154,15 @@ RSpec.describe MediaFilesController, type: :controller do
 
   describe "show" do
     let(:subject) { get :show, params: params }
-    let(:params) { { id: "1" } }
-    let(:media) { instance_double(MediaFile, media_type: "media type", attributes: {}, "attributes=": true, valid?: true, save: true) }
+    let(:params) { {id: "1"} }
+    let(:media) do
+      instance_double(MediaFile,
+                      media_type: "media type",
+                      attributes: {},
+                      "attributes=": true,
+                      valid?: true,
+                      save: true)
+    end
 
     it "uses QueryMediaFile to find the object" do
       expect(QueryMediaFile).to receive(:find).with(uuid: params[:id]).and_return(media)

--- a/spec/controllers/media_files_controller_spec.rb
+++ b/spec/controllers/media_files_controller_spec.rb
@@ -19,11 +19,11 @@ RSpec.describe MediaFilesController, type: :controller do
     context "when media is valid" do
       let(:media) do
         instance_double(MediaFile,
-                        media_type: "media type",
-                        attributes: {},
+                        "media_type": "media type",
+                        "attributes": {},
                         "uuid=": true,
-                        save: true,
-                        valid?: true)
+                        "save": true,
+                        "valid?": true)
       end
 
       before(:each) do
@@ -45,12 +45,12 @@ RSpec.describe MediaFilesController, type: :controller do
     context "when media is invalid" do
       let(:media) do
         instance_double(MediaFile,
-                        media_type: "media type",
-                        attributes: {},
+                        "media_type": "media type",
+                        "attributes": {},
                         "uuid=": true,
-                        save: false,
-                        valid?: false,
-                        errors: ["validation errors"])
+                        "save": false,
+                        "valid?": false,
+                        "errors": ["validation errors"])
       end
 
       before(:each) do
@@ -75,11 +75,11 @@ RSpec.describe MediaFilesController, type: :controller do
     let(:params) { {id: "1", media_file: {file_path: "file path", media_type: "media type"}} }
     let(:media) do
       instance_double(MediaFile,
-                      media_type: "media type",
-                      attributes: {},
+                      "media_type": "media type",
+                      "attributes": {},
                       "attributes=": true,
-                      valid?: true,
-                      save: true)
+                      "valid?": true,
+                      "save": true)
     end
 
     before(:each) do
@@ -99,12 +99,12 @@ RSpec.describe MediaFilesController, type: :controller do
     context "when media is valid" do
       let(:media) do
         instance_double(MediaFile,
-                        media_type: "media type",
-                        attributes: {},
+                        "media_type": "media type",
+                        "attributes": {},
                         "attributes=": true,
                         "uuid=": true,
-                        save: true,
-                        valid?: true)
+                        "save": true,
+                        "valid?": true)
       end
 
       before(:each) do
@@ -126,13 +126,13 @@ RSpec.describe MediaFilesController, type: :controller do
     context "when media is invalid" do
       let(:media) do
         instance_double(MediaFile,
-                        media_type: "media type",
-                        attributes: {},
+                        "media_type": "media type",
+                        "attributes": {},
                         "attributes=": true,
                         "uuid=": true,
-                        save: false,
-                        valid?: false,
-                        errors: ["validation errors"])
+                        "save": false,
+                        "valid?": false,
+                        "errors": ["validation errors"])
       end
 
       before(:each) do
@@ -157,11 +157,11 @@ RSpec.describe MediaFilesController, type: :controller do
     let(:params) { {id: "1"} }
     let(:media) do
       instance_double(MediaFile,
-                      media_type: "media type",
-                      attributes: {},
+                      "media_type": "media type",
+                      "attributes": {},
                       "attributes=": true,
-                      valid?: true,
-                      save: true)
+                      "valid?": true,
+                      "save": true)
     end
 
     it "uses QueryMediaFile to find the object" do

--- a/spec/models/media_file_spec.rb
+++ b/spec/models/media_file_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe MediaFile do
+  it "requires the file_path field" do
+    expect(subject).to have(1).errors_on(:file_path)
+  end
+
+  it "requires the uuid field" do
+    expect(subject).to have(1).errors_on(:uuid)
+  end
+
+  describe "media_type validator" do
+    it "requires a value" do
+      expect(subject).to have(1).errors_on(:media_type)
+    end
+
+    it "accepts video" do
+      subject.media_type = "video"
+      expect(subject).to have(0).errors_on(:media_type)
+    end
+
+    it "accepts audio" do
+      subject.media_type = "audio"
+      expect(subject).to have(0).errors_on(:media_type)
+    end
+
+    it "does not accept empty string" do
+      subject.media_type = ""
+      expect(subject).to have(1).errors_on(:media_type)
+    end
+
+    it "does not accept unknown value" do
+      subject.media_type = "something"
+      expect(subject).to have(1).errors_on(:media_type)
+    end
+  end
+end

--- a/spec/services/create_buzz_url_spec.rb
+++ b/spec/services/create_buzz_url_spec.rb
@@ -1,10 +1,7 @@
 require "rails_helper"
 
 describe CreateBuzzUrl do
-  let(:options) {{
-    host: "test.com",
-    port: "1000"
-  }}
+  let(:options) { {host: "test.com", port: "1000"} }
 
   before(:each) do
     allow(Rails.application.routes).to receive(:default_url_options).and_return(options)

--- a/spec/services/create_buzz_url_spec.rb
+++ b/spec/services/create_buzz_url_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+describe CreateBuzzUrl do
+  let(:options) {{
+    host: "test.com",
+    port: "1000"
+  }}
+
+  before(:each) do
+    allow(Rails.application.routes).to receive(:default_url_options).and_return(options)
+  end
+
+  it "returns the base path if no uri is given" do
+    expect(CreateBuzzUrl.call).to eq("https://test.com:1000")
+  end
+
+  it "returns the host path without port if no port is given" do
+    options.delete(:port)
+    expect(CreateBuzzUrl.call).to eq("https://test.com")
+  end
+
+  it "appends the given uri" do
+    expect(CreateBuzzUrl.call("my/uri")).to eq("https://test.com:1000/my/uri")
+  end
+end

--- a/spec/services/create_content_url_spec.rb
+++ b/spec/services/create_content_url_spec.rb
@@ -12,7 +12,6 @@ describe CreateContentUrl do
 
   before(:each) do
     allow(Rails.configuration.settings).to receive(:wowza).and_return(wowza_settings)
-    #Rails.configuration.settings.wowza = wowza_settings
   end
 
   context "when given a video file" do

--- a/spec/services/create_content_url_spec.rb
+++ b/spec/services/create_content_url_spec.rb
@@ -1,14 +1,16 @@
 require "rails_helper"
 
 describe CreateContentUrl do
-  let(:wowza_settings) {{
-    "host" => "wowza-test.com",
-    "port" => "1000",
-    "application" => "wowie",
-    "instance" => "instance",
-    "cache_source_prefix" => "source-prefix",
-    "cache_source" => "source"
-  }}
+  let(:wowza_settings) do
+    {
+      "host" => "wowza-test.com",
+      "port" => "1000",
+      "application" => "wowie",
+      "instance" => "instance",
+      "cache_source_prefix" => "source-prefix",
+      "cache_source" => "source"
+    }
+  end
 
   before(:each) do
     allow(Rails.configuration.settings).to receive(:wowza).and_return(wowza_settings)
@@ -18,11 +20,13 @@ describe CreateContentUrl do
     let(:object) { instance_double(MediaFile, media_type: "video", file_path: "file-path") }
 
     it "renders the correct http url" do
-      expect(CreateContentUrl.http(object: object)).to eq("http://wowza-test.com:1000/wowie/instance/mp4:source-prefix/source/file-path/playlist.m3u8")
+      expect(CreateContentUrl.http(object: object))
+        .to eq("http://wowza-test.com:1000/wowie/instance/mp4:source-prefix/source/file-path/playlist.m3u8")
     end
 
     it "renders the correct rtmp url" do
-      expect(CreateContentUrl.rtmp(object: object)).to eq("rtmp://wowza-test.com:1000/wowie/instance/mp4:source-prefix/source/file-path")
+      expect(CreateContentUrl.rtmp(object: object))
+        .to eq("rtmp://wowza-test.com:1000/wowie/instance/mp4:source-prefix/source/file-path")
     end
   end
 
@@ -30,11 +34,13 @@ describe CreateContentUrl do
     let(:object) { instance_double(MediaFile, media_type: "audio", file_path: "file-path") }
 
     it "renders the correct http url" do
-      expect(CreateContentUrl.http(object: object)).to eq("http://wowza-test.com:1000/wowie/instance/mp3:source-prefix/source/file-path/playlist.m3u8")
+      expect(CreateContentUrl.http(object: object))
+        .to eq("http://wowza-test.com:1000/wowie/instance/mp3:source-prefix/source/file-path/playlist.m3u8")
     end
 
     it "renders the correct rtmp url" do
-      expect(CreateContentUrl.rtmp(object: object)).to eq("rtmp://wowza-test.com:1000/wowie/instance/mp3:source-prefix/source/file-path")
+      expect(CreateContentUrl.rtmp(object: object))
+        .to eq("rtmp://wowza-test.com:1000/wowie/instance/mp3:source-prefix/source/file-path")
     end
   end
 end

--- a/spec/services/create_content_url_spec.rb
+++ b/spec/services/create_content_url_spec.rb
@@ -20,13 +20,13 @@ describe CreateContentUrl do
     let(:object) { instance_double(MediaFile, media_type: "video", file_path: "file-path") }
 
     it "renders the correct http url" do
-      expect(CreateContentUrl.http(object: object))
-        .to eq("http://wowza-test.com:1000/wowie/instance/mp4:source-prefix/source/file-path/playlist.m3u8")
+      url = "http://wowza-test.com:1000/wowie/instance/mp4:source-prefix/source/file-path/playlist.m3u8"
+      expect(CreateContentUrl.http(object: object)).to eq(url)
     end
 
     it "renders the correct rtmp url" do
-      expect(CreateContentUrl.rtmp(object: object))
-        .to eq("rtmp://wowza-test.com:1000/wowie/instance/mp4:source-prefix/source/file-path")
+      url = "rtmp://wowza-test.com:1000/wowie/instance/mp4:source-prefix/source/file-path"
+      expect(CreateContentUrl.rtmp(object: object)).to eq(url)
     end
   end
 
@@ -34,13 +34,13 @@ describe CreateContentUrl do
     let(:object) { instance_double(MediaFile, media_type: "audio", file_path: "file-path") }
 
     it "renders the correct http url" do
-      expect(CreateContentUrl.http(object: object))
-        .to eq("http://wowza-test.com:1000/wowie/instance/mp3:source-prefix/source/file-path/playlist.m3u8")
+      url = "http://wowza-test.com:1000/wowie/instance/mp3:source-prefix/source/file-path/playlist.m3u8"
+      expect(CreateContentUrl.http(object: object)).to eq(url)
     end
 
     it "renders the correct rtmp url" do
-      expect(CreateContentUrl.rtmp(object: object))
-        .to eq("rtmp://wowza-test.com:1000/wowie/instance/mp3:source-prefix/source/file-path")
+      url = "rtmp://wowza-test.com:1000/wowie/instance/mp3:source-prefix/source/file-path"
+      expect(CreateContentUrl.rtmp(object: object)).to eq(url)
     end
   end
 end

--- a/spec/services/create_content_url_spec.rb
+++ b/spec/services/create_content_url_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+describe CreateContentUrl do
+  let(:wowza_settings) {{
+    "host" => "wowza-test.com",
+    "port" => "1000",
+    "application" => "wowie",
+    "instance" => "instance",
+    "cache_source_prefix" => "source-prefix",
+    "cache_source" => "source"
+  }}
+
+  before(:each) do
+    allow(Rails.configuration.settings).to receive(:wowza).and_return(wowza_settings)
+    #Rails.configuration.settings.wowza = wowza_settings
+  end
+
+  context "when given a video file" do
+    let(:object) { instance_double(MediaFile, media_type: "video", file_path: "file-path") }
+
+    it "renders the correct http url" do
+      expect(CreateContentUrl.http(object: object)).to eq("http://wowza-test.com:1000/wowie/instance/mp4:source-prefix/source/file-path/playlist.m3u8")
+    end
+
+    it "renders the correct rtmp url" do
+      expect(CreateContentUrl.rtmp(object: object)).to eq("rtmp://wowza-test.com:1000/wowie/instance/mp4:source-prefix/source/file-path")
+    end
+  end
+
+  context "when given an audio file" do
+    let(:object) { instance_double(MediaFile, media_type: "audio", file_path: "file-path") }
+
+    it "renders the correct http url" do
+      expect(CreateContentUrl.http(object: object)).to eq("http://wowza-test.com:1000/wowie/instance/mp3:source-prefix/source/file-path/playlist.m3u8")
+    end
+
+    it "renders the correct rtmp url" do
+      expect(CreateContentUrl.rtmp(object: object)).to eq("rtmp://wowza-test.com:1000/wowie/instance/mp3:source-prefix/source/file-path")
+    end
+  end
+end

--- a/spec/services/query_media_file_spec.rb
+++ b/spec/services/query_media_file_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe QueryMediaFile do
-  let(:media) { MediaFile.new(uuid: "87ea8e9c-5932-478e-95d8-aeb04888a89a", file_path: "file path", media_type: "media type") }
+  let(:media) { MediaFile.new(uuid: "87ea8e9c-5932-478e-95d8-aeb04888a89a", file_path: "file path", media_type: "video", created_at: "2016-07-14 13:39:21", updated_at: "2016-07-14 13:39:21") }
 
   before(:each) do
     media.save

--- a/spec/services/query_media_file_spec.rb
+++ b/spec/services/query_media_file_spec.rb
@@ -1,7 +1,13 @@
 require "rails_helper"
 
 describe QueryMediaFile do
-  let(:media) { MediaFile.new(uuid: "87ea8e9c-5932-478e-95d8-aeb04888a89a", file_path: "file path", media_type: "video", created_at: "2016-07-14 13:39:21", updated_at: "2016-07-14 13:39:21") }
+  let(:media) do
+    MediaFile.new(uuid: "87ea8e9c-5932-478e-95d8-aeb04888a89a",
+                  file_path: "file path",
+                  media_type: "video",
+                  created_at: "2016-07-14 13:39:21",
+                  updated_at: "2016-07-14 13:39:21")
+  end
 
   before(:each) do
     media.save
@@ -13,7 +19,7 @@ describe QueryMediaFile do
     end
 
     it "throws an ActiveRecord::RecordNotFound exception if not found, so that controllers will 404" do
-      expect{ QueryMediaFile.find(uuid: 2) }.to raise_error(ActiveRecord::RecordNotFound)
+      expect { QueryMediaFile.find(uuid: 2) }.to raise_error(ActiveRecord::RecordNotFound)
     end
   end
 end

--- a/spec/services/serialize_audio_file_spec.rb
+++ b/spec/services/serialize_audio_file_spec.rb
@@ -1,26 +1,25 @@
 require "rails_helper"
 
 describe SerializeAudioFile do
-  let(:params) { { media_type: "media type" } }
-  let(:attributes) { { "id" => 1, "uuid" => "87ea8e9c-5932-478e-95d8-aeb04888a89a", "media_type" => "media type", "file_path" => "file path" } }
+  let(:params) {{ media_type: "media type" }}
+  let(:attributes) {{ "id" => 1, "uuid" => "87ea8e9c-5932-478e-95d8-aeb04888a89a", "media_type" => "media type", "file_path" => "file path" }}
   let(:media) { MediaFile.new(attributes) }
-  let(:audio_object) {
-    {
-      :@context=>"http://schema.org",
-      :@type=>"AudioObject",
-      :@id=>"87ea8e9c-5932-478e-95d8-aeb04888a89a",
-      :description=>"file path",
-      :name=>"file path",
-      :thumbnailUrl=>"https://test.host/audio.jpg",
-      :uploadDate=>nil,
-      :embedUrl=>"https://test.host/?id=87ea8e9c-5932-478e-95d8-aeb04888a89a",
-      :contentUrl=>[
+  let(:audio_object) {{
+    :@context=>"http://schema.org",
+    :@type=>"AudioObject",
+    :@id=>"87ea8e9c-5932-478e-95d8-aeb04888a89a",
+    :description=>"file path",
+    :name=>"file path",
+    :thumbnailUrl=>"https://test.host/audio.jpg",
+    :uploadDate=>nil,
+    :embedUrl=>"https://test.host/?id=87ea8e9c-5932-478e-95d8-aeb04888a89a",
+    :contentUrl=>
+      [
         "http://wowza.library.nd.edu:1935/buzz_wow/_definst_/mp3:amazons3/buzz-bucket.library.nd.edu/file path/playlist.m3u8",
         "rtmp://wowza.library.nd.edu:1935/buzz_wow/_definst_/mp3:amazons3/buzz-bucket.library.nd.edu/file path"
       ],
-      :url=>"http://test.host/v1/media_files/87ea8e9c-5932-478e-95d8-aeb04888a89a"
-    }
-  }
+    :url=>"http://test.host/v1/media_files/87ea8e9c-5932-478e-95d8-aeb04888a89a"
+  }}
 
   describe "to_hash" do
     let(:subject) { SerializeAudioFile.to_hash(object: media) }

--- a/spec/services/serialize_audio_file_spec.rb
+++ b/spec/services/serialize_audio_file_spec.rb
@@ -1,31 +1,39 @@
 require "rails_helper"
 
 describe SerializeAudioFile do
-  let(:params) {{ media_type: "media type" }}
-  let(:attributes) {{ "id" => 1, "uuid" => "87ea8e9c-5932-478e-95d8-aeb04888a89a", "media_type" => "media type", "file_path" => "file path" }}
+  let(:params) { {media_type: "media type"} }
+  let(:attributes) do
+    {
+      "id" => 1,
+      "uuid" => "87ea8e9c-5932-478e-95d8-aeb04888a89a",
+      "media_type" => "media type",
+      "file_path" => "file path"
+    }
+  end
   let(:media) { MediaFile.new(attributes) }
-  let(:audio_object) {{
-    :@context=>"http://schema.org",
-    :@type=>"AudioObject",
-    :@id=>"87ea8e9c-5932-478e-95d8-aeb04888a89a",
-    :description=>"file path",
-    :name=>"file path",
-    :thumbnailUrl=>"https://test.host/audio.jpg",
-    :uploadDate=>nil,
-    :embedUrl=>"https://test.host/?id=87ea8e9c-5932-478e-95d8-aeb04888a89a",
-    :contentUrl=>
-      [
+  let(:audio_object) do
+    {
+      :@context => "http://schema.org",
+      :@type => "AudioObject",
+      :@id => "87ea8e9c-5932-478e-95d8-aeb04888a89a",
+      :description => "file path",
+      :name => "file path",
+      :thumbnailUrl => "https://test.host/audio.jpg",
+      :uploadDate => nil,
+      :embedUrl => "https://test.host/?id=87ea8e9c-5932-478e-95d8-aeb04888a89a",
+      :contentUrl => [
         "http://wowza.library.nd.edu:1935/buzz_wow/_definst_/mp3:amazons3/buzz-bucket.library.nd.edu/file path/playlist.m3u8",
         "rtmp://wowza.library.nd.edu:1935/buzz_wow/_definst_/mp3:amazons3/buzz-bucket.library.nd.edu/file path"
       ],
-    :url=>"http://test.host/v1/media_files/87ea8e9c-5932-478e-95d8-aeb04888a89a"
-  }}
+      :url => "http://test.host/v1/media_files/87ea8e9c-5932-478e-95d8-aeb04888a89a"
+    }
+  end
 
   describe "to_hash" do
     let(:subject) { SerializeAudioFile.to_hash(object: media) }
 
     it "excludes id" do
-      expect(subject).not_to include(:"id")
+      expect(subject).not_to include(:id)
     end
 
     it "includes all other attributes" do
@@ -37,7 +45,7 @@ describe SerializeAudioFile do
     let(:subject) { JSON.parse(SerializeAudioFile.to_json(object: media), symbolize_names: true) }
 
     it "excludes id" do
-      expect(subject).not_to include(:"id")
+      expect(subject).not_to include(:id)
     end
 
     it "includes all other attributes" do

--- a/spec/services/serialize_audio_file_spec.rb
+++ b/spec/services/serialize_audio_file_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+describe SerializeAudioFile do
+  let(:params) { { media_type: "media type" } }
+  let(:attributes) { { "id" => 1, "uuid" => "87ea8e9c-5932-478e-95d8-aeb04888a89a", "media_type" => "media type", "file_path" => "file path" } }
+  let(:media) { MediaFile.new(attributes) }
+  let(:audio_object) {
+    {
+      :@context=>"http://schema.org",
+      :@type=>"AudioObject",
+      :@id=>"87ea8e9c-5932-478e-95d8-aeb04888a89a",
+      :description=>"file path",
+      :name=>"file path",
+      :thumbnailUrl=>"https://test.host/audio.jpg",
+      :uploadDate=>nil,
+      :embedUrl=>"https://test.host/?id=87ea8e9c-5932-478e-95d8-aeb04888a89a",
+      :contentUrl=>[
+        "http://wowza.library.nd.edu:1935/buzz_wow/_definst_/mp3:amazons3/buzz-bucket.library.nd.edu/file path/playlist.m3u8",
+        "rtmp://wowza.library.nd.edu:1935/buzz_wow/_definst_/mp3:amazons3/buzz-bucket.library.nd.edu/file path"
+      ],
+      :url=>"http://test.host/v1/media_files/87ea8e9c-5932-478e-95d8-aeb04888a89a"
+    }
+  }
+
+  describe "to_hash" do
+    let(:subject) { SerializeAudioFile.to_hash(object: media) }
+
+    it "excludes id" do
+      expect(subject).not_to include(:"id")
+    end
+
+    it "includes all other attributes" do
+      expect(subject).to eq(audio_object)
+    end
+  end
+
+  describe "to_json" do
+    let(:subject) { JSON.parse(SerializeAudioFile.to_json(object: media), symbolize_names: true) }
+
+    it "excludes id" do
+      expect(subject).not_to include(:"id")
+    end
+
+    it "includes all other attributes" do
+      expect(subject).to eq(audio_object)
+    end
+  end
+end

--- a/spec/services/serialize_media_file_spec.rb
+++ b/spec/services/serialize_media_file_spec.rb
@@ -11,7 +11,7 @@ describe SerializeMediaFile do
     end
 
     it "assigns the attributes from the hash" do
-      expect(SerializeMediaFile.from_hash(hash: attributes).attributes).to eq(attributes)
+      expect(SerializeMediaFile.from_hash(hash: attributes).attributes).to include(attributes)
     end
 
     it "raises an error for an invalid param" do
@@ -20,27 +20,45 @@ describe SerializeMediaFile do
     end
   end
 
-  describe "to_hash" do
-    let(:subject) { SerializeMediaFile.to_hash(object: media) }
+  context "when its an audio type" do
+    let(:attributes) { { "id" => 1, "uuid" => "87ea8e9c-5932-478e-95d8-aeb04888a89a", "media_type" => "audio", "file_path" => "file path" } }
 
-    it "excludes id" do
-      expect(subject).not_to include(:"id")
+    it "uses SerializeAudioFile.to_hash" do
+      expect(SerializeAudioFile).to receive(:to_hash).with(object: media)
+      SerializeMediaFile.to_hash(object: media)
     end
 
-    it "includes all other attributes" do
-      expect(subject).to include("uuid", "file_path", "media_type")
+    it "uses SerializeAudioFile.to_hash to convert to json" do
+      expect(SerializeAudioFile).to receive(:to_hash).with(object: media)
+      SerializeMediaFile.to_json(object: media)
     end
   end
 
-  describe "to_json" do
-    let(:subject) { JSON.parse(SerializeMediaFile.to_json(object: media), symbolize_names: true) }
+  context "when its a video type" do
+    let(:attributes) { { "id" => 1, "uuid" => "87ea8e9c-5932-478e-95d8-aeb04888a89a", "media_type" => "video", "file_path" => "file path" } }
 
-    it "excludes id" do
-      expect(subject).not_to include(:"id")
+    it "uses SerializeVideoFile.to_hash" do
+      expect(SerializeVideoFile).to receive(:to_hash).with(object: media)
+      SerializeMediaFile.to_hash(object: media)
     end
 
-    it "includes all other attributes" do
-      expect(subject).to include(:"uuid", :"file_path", :"media_type")
+    it "uses SerializeVideoFile.to_hash to convert to json" do
+      expect(SerializeVideoFile).to receive(:to_hash).with(object: media)
+      SerializeMediaFile.to_json(object: media)
+    end
+  end
+
+  context "when its an unknown type" do
+    let(:attributes) { { "id" => 1, "uuid" => "87ea8e9c-5932-478e-95d8-aeb04888a89a", "media_type" => "this type is unknown", "file_path" => "file path" } }
+
+    it "uses SerializeUnknownTypeFile.to_hash" do
+      expect(SerializeUnknownTypeFile).to receive(:to_hash).with(object: media)
+      SerializeMediaFile.to_hash(object: media)
+    end
+
+    it "uses SerializeUnknownTypeFile.to_hash to convert to json" do
+      expect(SerializeUnknownTypeFile).to receive(:to_hash).with(object: media)
+      SerializeMediaFile.to_json(object: media)
     end
   end
 end

--- a/spec/services/serialize_media_file_spec.rb
+++ b/spec/services/serialize_media_file_spec.rb
@@ -1,8 +1,15 @@
 require "rails_helper"
 
 describe SerializeMediaFile do
-  let(:params) { { media_type: "media type" } }
-  let(:attributes) { { "id" => 1, "uuid" => "87ea8e9c-5932-478e-95d8-aeb04888a89a", "media_type" => "media type", "file_path" => "file path" } }
+  let(:params) { {media_type: "media type"} }
+  let(:attributes) do
+    {
+      "id" => 1,
+      "uuid" => "87ea8e9c-5932-478e-95d8-aeb04888a89a",
+      "media_type" => "media type",
+      "file_path" => "file path"
+    }
+  end
   let(:media) { MediaFile.new(attributes) }
 
   describe "from_hash" do
@@ -16,12 +23,19 @@ describe SerializeMediaFile do
 
     it "raises an error for an invalid param" do
       attributes["blah"] = "bleh"
-      expect{ SerializeMediaFile.from_hash(hash: attributes) }.to raise_error(ActiveModel::UnknownAttributeError)
+      expect { SerializeMediaFile.from_hash(hash: attributes) }.to raise_error(ActiveModel::UnknownAttributeError)
     end
   end
 
   context "when its an audio type" do
-    let(:attributes) { { "id" => 1, "uuid" => "87ea8e9c-5932-478e-95d8-aeb04888a89a", "media_type" => "audio", "file_path" => "file path" } }
+    let(:attributes) do
+      {
+        "id" => 1,
+        "uuid" => "87ea8e9c-5932-478e-95d8-aeb04888a89a",
+        "media_type" => "audio",
+        "file_path" => "file path"
+      }
+    end
 
     it "uses SerializeAudioFile.to_hash" do
       expect(SerializeAudioFile).to receive(:to_hash).with(object: media)
@@ -35,7 +49,14 @@ describe SerializeMediaFile do
   end
 
   context "when its a video type" do
-    let(:attributes) { { "id" => 1, "uuid" => "87ea8e9c-5932-478e-95d8-aeb04888a89a", "media_type" => "video", "file_path" => "file path" } }
+    let(:attributes) do
+      {
+        "id" => 1,
+        "uuid" => "87ea8e9c-5932-478e-95d8-aeb04888a89a",
+        "media_type" => "video",
+        "file_path" => "file path"
+      }
+    end
 
     it "uses SerializeVideoFile.to_hash" do
       expect(SerializeVideoFile).to receive(:to_hash).with(object: media)
@@ -49,7 +70,14 @@ describe SerializeMediaFile do
   end
 
   context "when its an unknown type" do
-    let(:attributes) { { "id" => 1, "uuid" => "87ea8e9c-5932-478e-95d8-aeb04888a89a", "media_type" => "this type is unknown", "file_path" => "file path" } }
+    let(:attributes) do
+      {
+        "id" => 1,
+        "uuid" => "87ea8e9c-5932-478e-95d8-aeb04888a89a",
+        "media_type" => "this type is unknown",
+        "file_path" => "file path"
+      }
+    end
 
     it "uses SerializeUnknownTypeFile.to_hash" do
       expect(SerializeUnknownTypeFile).to receive(:to_hash).with(object: media)

--- a/spec/services/serialize_unknown_type_file_spec.rb
+++ b/spec/services/serialize_unknown_type_file_spec.rb
@@ -1,15 +1,22 @@
 require "rails_helper"
 
 describe SerializeUnknownTypeFile do
-  let(:params) {{ media_type: "media type" }}
-  let(:attributes) {{ "id" => 1, "uuid" => "87ea8e9c-5932-478e-95d8-aeb04888a89a", "media_type" => "media type", "file_path" => "file path" }}
+  let(:params) { {media_type: "media type"} }
+  let(:attributes) do
+    {
+      "id" => 1,
+      "uuid" => "87ea8e9c-5932-478e-95d8-aeb04888a89a",
+      "media_type" => "media type",
+      "file_path" => "file path"
+    }
+  end
   let(:media) { MediaFile.new(attributes) }
 
   describe "to_hash" do
     let(:subject) { SerializeUnknownTypeFile.to_hash(object: media) }
 
     it "excludes id" do
-      expect(subject).not_to include(:"id")
+      expect(subject).not_to include(:id)
     end
 
     it "includes all other attributes" do
@@ -21,11 +28,11 @@ describe SerializeUnknownTypeFile do
     let(:subject) { JSON.parse(SerializeUnknownTypeFile.to_json(object: media), symbolize_names: true) }
 
     it "excludes id" do
-      expect(subject).not_to include(:"id")
+      expect(subject).not_to include(:id)
     end
 
     it "includes all other attributes" do
-      expect(subject).to include(:"file_path", :"media_type")
+      expect(subject).to include(:file_path, :media_type)
     end
   end
 end

--- a/spec/services/serialize_unknown_type_file_spec.rb
+++ b/spec/services/serialize_unknown_type_file_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+describe SerializeUnknownTypeFile do
+  let(:params) { { media_type: "media type" } }
+  let(:attributes) { { "id" => 1, "uuid" => "87ea8e9c-5932-478e-95d8-aeb04888a89a", "media_type" => "media type", "file_path" => "file path" } }
+  let(:media) { MediaFile.new(attributes) }
+
+  describe "to_hash" do
+    let(:subject) { SerializeUnknownTypeFile.to_hash(object: media) }
+
+    it "excludes id" do
+      expect(subject).not_to include(:"id")
+    end
+
+    it "includes all other attributes" do
+      expect(subject).to include("file_path", "media_type")
+    end
+  end
+
+  describe "to_json" do
+    let(:subject) { JSON.parse(SerializeUnknownTypeFile.to_json(object: media), symbolize_names: true) }
+
+    it "excludes id" do
+      expect(subject).not_to include(:"id")
+    end
+
+    it "includes all other attributes" do
+      expect(subject).to include(:"file_path", :"media_type")
+    end
+  end
+end

--- a/spec/services/serialize_unknown_type_file_spec.rb
+++ b/spec/services/serialize_unknown_type_file_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
 describe SerializeUnknownTypeFile do
-  let(:params) { { media_type: "media type" } }
-  let(:attributes) { { "id" => 1, "uuid" => "87ea8e9c-5932-478e-95d8-aeb04888a89a", "media_type" => "media type", "file_path" => "file path" } }
+  let(:params) {{ media_type: "media type" }}
+  let(:attributes) {{ "id" => 1, "uuid" => "87ea8e9c-5932-478e-95d8-aeb04888a89a", "media_type" => "media type", "file_path" => "file path" }}
   let(:media) { MediaFile.new(attributes) }
 
   describe "to_hash" do

--- a/spec/services/serialize_video_file_spec.rb
+++ b/spec/services/serialize_video_file_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+describe SerializeVideoFile do
+  let(:params) { { media_type: "media type" } }
+  let(:attributes) { { "id" => 1, "uuid" => "87ea8e9c-5932-478e-95d8-aeb04888a89a", "media_type" => "media type", "file_path" => "file path" } }
+  let(:media) { MediaFile.new(attributes) }
+  let(:audio_object) {
+    {
+      :@context=>"http://schema.org",
+      :@type=>"VideoObject",
+      :@id=>"87ea8e9c-5932-478e-95d8-aeb04888a89a",
+      :description=>"file path",
+      :name=>"file path",
+      :thumbnailUrl=>"https://test.host/video.jpg",
+      :uploadDate=>nil,
+      :embedUrl=>"https://test.host/?id=87ea8e9c-5932-478e-95d8-aeb04888a89a",
+      :contentUrl=>[
+        "http://wowza.library.nd.edu:1935/buzz_wow/_definst_/mp3:amazons3/buzz-bucket.library.nd.edu/file path/playlist.m3u8",
+        "rtmp://wowza.library.nd.edu:1935/buzz_wow/_definst_/mp3:amazons3/buzz-bucket.library.nd.edu/file path"
+      ],
+      :url=>"http://test.host/v1/media_files/87ea8e9c-5932-478e-95d8-aeb04888a89a"
+    }
+  }
+
+  describe "to_hash" do
+    let(:subject) { SerializeVideoFile.to_hash(object: media) }
+
+    it "excludes id" do
+      expect(subject).not_to include(:"id")
+    end
+
+    it "includes all other attributes" do
+      expect(subject).to eq(audio_object)
+    end
+  end
+
+  describe "to_json" do
+    let(:subject) { JSON.parse(SerializeVideoFile.to_json(object: media), symbolize_names: true) }
+
+    it "excludes id" do
+      expect(subject).not_to include(:"id")
+    end
+
+    it "includes all other attributes" do
+      expect(subject).to eq(audio_object)
+    end
+  end
+end

--- a/spec/services/serialize_video_file_spec.rb
+++ b/spec/services/serialize_video_file_spec.rb
@@ -1,32 +1,31 @@
 require "rails_helper"
 
 describe SerializeVideoFile do
-  let(:params) { { media_type: "media type" } }
-  let(:attributes) { { "id" => 1, "uuid" => "87ea8e9c-5932-478e-95d8-aeb04888a89a", "media_type" => "media type", "file_path" => "file path" } }
+  let(:params) {{ media_type: "media type" }}
+  let(:attributes) {{ "id" => 1, "uuid" => "87ea8e9c-5932-478e-95d8-aeb04888a89a", "media_type" => "media type", "file_path" => "file path" }}
   let(:media) { MediaFile.new(attributes) }
-  let(:audio_object) {
-    {
-      :@context=>"http://schema.org",
-      :@type=>"VideoObject",
-      :@id=>"87ea8e9c-5932-478e-95d8-aeb04888a89a",
-      :description=>"file path",
-      :name=>"file path",
-      :thumbnailUrl=>"https://test.host/video.jpg",
-      :uploadDate=>nil,
-      :embedUrl=>"https://test.host/?id=87ea8e9c-5932-478e-95d8-aeb04888a89a",
-      :contentUrl=>[
+  let(:audio_object) {{
+    :@context=>"http://schema.org",
+    :@type=>"VideoObject",
+    :@id=>"87ea8e9c-5932-478e-95d8-aeb04888a89a",
+    :description=>"file path",
+    :name=>"file path",
+    :thumbnailUrl=>"https://test.host/video.jpg",
+    :uploadDate=>nil,
+    :embedUrl=>"https://test.host/?id=87ea8e9c-5932-478e-95d8-aeb04888a89a",
+    :contentUrl=>
+      [
         "http://wowza.library.nd.edu:1935/buzz_wow/_definst_/mp3:amazons3/buzz-bucket.library.nd.edu/file path/playlist.m3u8",
         "rtmp://wowza.library.nd.edu:1935/buzz_wow/_definst_/mp3:amazons3/buzz-bucket.library.nd.edu/file path"
       ],
-      :url=>"http://test.host/v1/media_files/87ea8e9c-5932-478e-95d8-aeb04888a89a"
-    }
-  }
+    :url=>"http://test.host/v1/media_files/87ea8e9c-5932-478e-95d8-aeb04888a89a"
+  }}
 
   describe "to_hash" do
     let(:subject) { SerializeVideoFile.to_hash(object: media) }
 
     it "excludes id" do
-      expect(subject).not_to include(:"id")
+      expect(subject).not_to include(:id)
     end
 
     it "includes all other attributes" do
@@ -38,7 +37,7 @@ describe SerializeVideoFile do
     let(:subject) { JSON.parse(SerializeVideoFile.to_json(object: media), symbolize_names: true) }
 
     it "excludes id" do
-      expect(subject).not_to include(:"id")
+      expect(subject).not_to include(:id)
     end
 
     it "includes all other attributes" do

--- a/spec/services/serialize_video_file_spec.rb
+++ b/spec/services/serialize_video_file_spec.rb
@@ -1,25 +1,33 @@
 require "rails_helper"
 
 describe SerializeVideoFile do
-  let(:params) {{ media_type: "media type" }}
-  let(:attributes) {{ "id" => 1, "uuid" => "87ea8e9c-5932-478e-95d8-aeb04888a89a", "media_type" => "media type", "file_path" => "file path" }}
+  let(:params) { {media_type: "media type"} }
+  let(:attributes) do
+    {
+      "id" => 1,
+      "uuid" => "87ea8e9c-5932-478e-95d8-aeb04888a89a",
+      "media_type" => "media type",
+      "file_path" => "file path"
+    }
+  end
   let(:media) { MediaFile.new(attributes) }
-  let(:audio_object) {{
-    :@context=>"http://schema.org",
-    :@type=>"VideoObject",
-    :@id=>"87ea8e9c-5932-478e-95d8-aeb04888a89a",
-    :description=>"file path",
-    :name=>"file path",
-    :thumbnailUrl=>"https://test.host/video.jpg",
-    :uploadDate=>nil,
-    :embedUrl=>"https://test.host/?id=87ea8e9c-5932-478e-95d8-aeb04888a89a",
-    :contentUrl=>
-      [
+  let(:audio_object) do
+    {
+      :@context => "http://schema.org",
+      :@type => "VideoObject",
+      :@id => "87ea8e9c-5932-478e-95d8-aeb04888a89a",
+      :description => "file path",
+      :name => "file path",
+      :thumbnailUrl => "https://test.host/video.jpg",
+      :uploadDate => nil,
+      :embedUrl =>"https://test.host/?id=87ea8e9c-5932-478e-95d8-aeb04888a89a",
+      :contentUrl => [
         "http://wowza.library.nd.edu:1935/buzz_wow/_definst_/mp3:amazons3/buzz-bucket.library.nd.edu/file path/playlist.m3u8",
         "rtmp://wowza.library.nd.edu:1935/buzz_wow/_definst_/mp3:amazons3/buzz-bucket.library.nd.edu/file path"
       ],
-    :url=>"http://test.host/v1/media_files/87ea8e9c-5932-478e-95d8-aeb04888a89a"
-  }}
+      :url => "http://test.host/v1/media_files/87ea8e9c-5932-478e-95d8-aeb04888a89a"
+    }
+  end
 
   describe "to_hash" do
     let(:subject) { SerializeVideoFile.to_hash(object: media) }

--- a/spec/services/serialize_video_file_spec.rb
+++ b/spec/services/serialize_video_file_spec.rb
@@ -20,7 +20,7 @@ describe SerializeVideoFile do
       :name => "file path",
       :thumbnailUrl => "https://test.host/video.jpg",
       :uploadDate => nil,
-      :embedUrl =>"https://test.host/?id=87ea8e9c-5932-478e-95d8-aeb04888a89a",
+      :embedUrl => "https://test.host/?id=87ea8e9c-5932-478e-95d8-aeb04888a89a",
       :contentUrl => [
         "http://wowza.library.nd.edu:1935/buzz_wow/_definst_/mp3:amazons3/buzz-bucket.library.nd.edu/file path/playlist.m3u8",
         "rtmp://wowza.library.nd.edu:1935/buzz_wow/_definst_/mp3:amazons3/buzz-bucket.library.nd.edu/file path"


### PR DESCRIPTION
This changes media files to render AudioObjects and VideoObjects based on the schema.org context. The type of object that will be rendered depends on the file's media_type, so I had to add some additional validation and handling around that. I also added app host and wowza host settings so that we can configure these independently on the deployed systems, and added url generating services that use these configs.