### PR TITLE
DEC-1241 Error editing audio file item record

### DIFF
--- a/app/services/create_content_url.rb
+++ b/app/services/create_content_url.rb
@@ -16,7 +16,7 @@ class CreateContentUrl
   private
 
   def self.prefix(object:)
-    if object.media_type.downcase == "video"
+    if object.media_type.downcase == "video" || File.extname(object.file_path) == ".m4a"
       "mp4"
     else
       "mp3"

--- a/app/services/create_content_url.rb
+++ b/app/services/create_content_url.rb
@@ -16,7 +16,7 @@ class CreateContentUrl
   private
 
   def self.prefix(object:)
-    if object.media_type.casecmp("video") === 0 || File.extname(object.file_path).casecmp(".m4a") === 0
+    if object.media_type.casecmp("video") == 0 || File.extname(object.file_path).casecmp(".m4a") == 0
       "mp4"
     else
       "mp3"

--- a/app/services/create_content_url.rb
+++ b/app/services/create_content_url.rb
@@ -16,7 +16,7 @@ class CreateContentUrl
   private
 
   def self.prefix(object:)
-    if object.media_type.casecmp("video") == 0 || File.extname(object.file_path).casecmp(".m4a") == 0
+    if object.media_type.casecmp("video").zero? || File.extname(object.file_path).casecmp(".m4a").zero?
       "mp4"
     else
       "mp3"

--- a/app/services/create_content_url.rb
+++ b/app/services/create_content_url.rb
@@ -16,7 +16,7 @@ class CreateContentUrl
   private
 
   def self.prefix(object:)
-    if object.media_type.downcase == "video" || File.extname(object.file_path) == ".m4a"
+    if object.media_type.casecmp("video") || File.extname(object.file_path).casecmp(".m4a")
       "mp4"
     else
       "mp3"

--- a/app/services/create_content_url.rb
+++ b/app/services/create_content_url.rb
@@ -16,7 +16,7 @@ class CreateContentUrl
   private
 
   def self.prefix(object:)
-    if object.media_type.casecmp("video") || File.extname(object.file_path).casecmp(".m4a")
+    if object.media_type.casecmp("video") === 0 || File.extname(object.file_path).casecmp(".m4a") === 0
       "mp4"
     else
       "mp3"

--- a/spec/services/create_content_url_spec.rb
+++ b/spec/services/create_content_url_spec.rb
@@ -43,4 +43,18 @@ describe CreateContentUrl do
       expect(CreateContentUrl.rtmp(object: object)).to eq(url)
     end
   end
+
+  context "when given an .m4a audio file" do
+    let(:object) { instance_double(MediaFile, media_type: "audio", file_path: "file-path.m4a") }
+
+    it "renders the correct http url" do
+      url = "http://wowza-test.com:1000/wowie/instance/mp4:source-prefix/source/file-path.m4a/playlist.m3u8"
+      expect(CreateContentUrl.http(object: object)).to eq(url)
+    end
+
+    it "renders the correct rtmp url" do
+      url = "rtmp://wowza-test.com:1000/wowie/instance/mp4:source-prefix/source/file-path.m4a"
+      expect(CreateContentUrl.rtmp(object: object)).to eq(url)
+    end
+  end
 end


### PR DESCRIPTION
Problem: Someone uploaded an m4a audio file. This file type is supported by Wowza, but would not work in Buzz as currently configured. ".m4a"  requires the mp4/quicktime
wrapper instead of the mp3 wrapper in the Wowza media request url.

Solution: We do a special file extension test to make it work correctly.