### PR TITLE
Update media urls to use ssl to ensure playback on Chrome 58+

### DIFF
--- a/app/services/create_content_url.rb
+++ b/app/services/create_content_url.rb
@@ -1,13 +1,13 @@
 class CreateContentUrl
   def self.http(object:)
-    "http://#{settings["host"]}:#{settings["port"]}" \
+    "https://#{settings["host"]}:#{settings["port"]}" \
           "/#{settings["application"]}/#{settings["instance"]}" \
           "/#{prefix(object:object)}:#{settings["cache_source_prefix"]}/#{settings["cache_source"]}" \
           "/#{object.file_path}/playlist.m3u8"
   end
 
   def self.rtmp(object:)
-    "rtmp://#{settings["host"]}:#{settings["port"]}" \
+    "rtmps://#{settings["host"]}:#{settings["port"]}" \
           "/#{settings["application"]}/#{settings["instance"]}" \
           "/#{prefix(object:object)}:#{settings["cache_source_prefix"]}/#{settings["cache_source"]}" \
           "/#{object.file_path}"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -2,11 +2,12 @@
 defaults: &defaults
   wowza:
     host: wowza.library.nd.edu
-    port: 1935
+    port: 443
     application: buzz_wow
     instance: _definst_
     cache_source_prefix: amazons3
-    cache_source: buzz-bucket.library.nd.edu
+    cache_source: testlibnd-wse-honeycomb-pprd
+    #cache_source: honeycomb-media-wse-library-nd-edu
 
 local: &local
   <<: *defaults
@@ -24,18 +25,18 @@ pre_production:
   <<: *deploy
   wowza:
     host: wowza.library.nd.edu
-    port: 1935
+    port: 443
     application: buzz_wow
     instance: _definst_
-    cache_source_prefix: amazons3    
+    cache_source_prefix: amazons3
     cache_source: testlibnd-wse-honeycomb-pprd
 
 production:
   <<: *deploy
   wowza:
     host: wowza.library.nd.edu
-    port: 1935
+    port: 443
     application: buzz_wow
     instance: _definst_
     cache_source_prefix: amazons3
-    cache_source: honeycomb-media-library-nd-edu
+    cache_source: honeycomb-media-wse-library-nd-edu

--- a/spec/services/create_content_url_spec.rb
+++ b/spec/services/create_content_url_spec.rb
@@ -20,12 +20,12 @@ describe CreateContentUrl do
     let(:object) { instance_double(MediaFile, media_type: "video", file_path: "file-path") }
 
     it "renders the correct http url" do
-      url = "http://wowza-test.com:1000/wowie/instance/mp4:source-prefix/source/file-path/playlist.m3u8"
+      url = "https://wowza-test.com:1000/wowie/instance/mp4:source-prefix/source/file-path/playlist.m3u8"
       expect(CreateContentUrl.http(object: object)).to eq(url)
     end
 
     it "renders the correct rtmp url" do
-      url = "rtmp://wowza-test.com:1000/wowie/instance/mp4:source-prefix/source/file-path"
+      url = "rtmps://wowza-test.com:1000/wowie/instance/mp4:source-prefix/source/file-path"
       expect(CreateContentUrl.rtmp(object: object)).to eq(url)
     end
   end
@@ -34,12 +34,12 @@ describe CreateContentUrl do
     let(:object) { instance_double(MediaFile, media_type: "audio", file_path: "file-path") }
 
     it "renders the correct http url" do
-      url = "http://wowza-test.com:1000/wowie/instance/mp3:source-prefix/source/file-path/playlist.m3u8"
+      url = "https://wowza-test.com:1000/wowie/instance/mp3:source-prefix/source/file-path/playlist.m3u8"
       expect(CreateContentUrl.http(object: object)).to eq(url)
     end
 
     it "renders the correct rtmp url" do
-      url = "rtmp://wowza-test.com:1000/wowie/instance/mp3:source-prefix/source/file-path"
+      url = "rtmps://wowza-test.com:1000/wowie/instance/mp3:source-prefix/source/file-path"
       expect(CreateContentUrl.rtmp(object: object)).to eq(url)
     end
   end
@@ -48,12 +48,12 @@ describe CreateContentUrl do
     let(:object) { instance_double(MediaFile, media_type: "audio", file_path: "file-path.m4a") }
 
     it "renders the correct http url" do
-      url = "http://wowza-test.com:1000/wowie/instance/mp4:source-prefix/source/file-path.m4a/playlist.m3u8"
+      url = "https://wowza-test.com:1000/wowie/instance/mp4:source-prefix/source/file-path.m4a/playlist.m3u8"
       expect(CreateContentUrl.http(object: object)).to eq(url)
     end
 
     it "renders the correct rtmp url" do
-      url = "rtmp://wowza-test.com:1000/wowie/instance/mp4:source-prefix/source/file-path.m4a"
+      url = "rtmps://wowza-test.com:1000/wowie/instance/mp4:source-prefix/source/file-path.m4a"
       expect(CreateContentUrl.rtmp(object: object)).to eq(url)
     end
   end

--- a/spec/services/serialize_audio_file_spec.rb
+++ b/spec/services/serialize_audio_file_spec.rb
@@ -23,8 +23,8 @@ describe SerializeAudioFile do
       :uploadDate => nil,
       :embedUrl => "http://test.host/?id=87ea8e9c-5932-478e-95d8-aeb04888a89a",
       :contentUrl => [
-        "http://wowza.library.nd.edu:1935/buzz_wow/_definst_/mp3:amazons3/buzz-bucket.library.nd.edu/file path/playlist.m3u8",
-        "rtmp://wowza.library.nd.edu:1935/buzz_wow/_definst_/mp3:amazons3/buzz-bucket.library.nd.edu/file path"
+        "https://wowza.library.nd.edu:443/buzz_wow/_definst_/mp3:amazons3/testlibnd-wse-honeycomb-pprd/file path/playlist.m3u8",
+        "rtmps://wowza.library.nd.edu:443/buzz_wow/_definst_/mp3:amazons3/testlibnd-wse-honeycomb-pprd/file path"
       ],
       :url => "http://test.host/v1/media_files/87ea8e9c-5932-478e-95d8-aeb04888a89a"
     }

--- a/spec/services/serialize_video_file_spec.rb
+++ b/spec/services/serialize_video_file_spec.rb
@@ -23,8 +23,8 @@ describe SerializeVideoFile do
       :uploadDate => nil,
       :embedUrl => "http://test.host/?id=87ea8e9c-5932-478e-95d8-aeb04888a89a",
       :contentUrl => [
-        "http://wowza.library.nd.edu:1935/buzz_wow/_definst_/mp3:amazons3/buzz-bucket.library.nd.edu/file path/playlist.m3u8",
-        "rtmp://wowza.library.nd.edu:1935/buzz_wow/_definst_/mp3:amazons3/buzz-bucket.library.nd.edu/file path"
+        "https://wowza.library.nd.edu:443/buzz_wow/_definst_/mp3:amazons3/testlibnd-wse-honeycomb-pprd/file path/playlist.m3u8",
+        "rtmps://wowza.library.nd.edu:443/buzz_wow/_definst_/mp3:amazons3/testlibnd-wse-honeycomb-pprd/file path"
       ],
       :url => "http://test.host/v1/media_files/87ea8e9c-5932-478e-95d8-aeb04888a89a"
     }


### PR DESCRIPTION
* Update media urls to use ssl to ensure playback on Chrome 58+
* Fix incorrect cache_source variable in production