### PR TITLE
remove chamber to allow ECS to handle env

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,6 +36,6 @@ WORKDIR $APP_HOME
 #ENV RAILS_ENV=production
 
 RUN chmod u+x docker/entry.sh docker/start_services.sh
-ENTRYPOINT ["bash", "docker/entry.sh"]
+# ENTRYPOINT ["bash", "docker/entry.sh"]
 # By default, start the required services
 CMD docker/start_services.sh

--- a/docker/entry.sh
+++ b/docker/entry.sh
@@ -1,2 +1,2 @@
 echo Mapping SSM path "$ENV_SSM_PATH" to my environment.
-exec chamber exec $ENV_SSM_PATH -- "$@"
+# exec chamber exec $ENV_SSM_PATH -- "$@"


### PR DESCRIPTION
We've moved off of Chamber for ECS parameters. I could delete the lines, but as I'm working through the deploy thought it might be better to have them available in case I need to bring them back.