### PR TITLE
More configuration through env

### DIFF
--- a/config/environments/pre_production.rb
+++ b/config/environments/pre_production.rb
@@ -76,8 +76,10 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
+  host = ENV['DEFAULT_URL_HOST'] || "buzz-prep.library.nd.edu"
+  protocol = ENV['DEFAULT_URL_PROTOCOL'] || "http"
   Rails.application.routes.default_url_options = {
-    host: "buzz-prep.library.nd.edu",
-    protocol: "http"
+    host: host,
+    protocol: protocol
   }
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -76,8 +76,11 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
+  host = ENV['DEFAULT_URL_HOST'] || "buzz.library.nd.edu"
+  protocol = ENV['DEFAULT_URL_PROTOCOL'] || "https"
   Rails.application.routes.default_url_options = {
-    host: "buzz.library.nd.edu",
-    protocol: "https"
+    host: host,
+    protocol: protocol
   }
+  puts Rails.application.routes.default_url_options
 end

--- a/config/initializers/application_settings.rb
+++ b/config/initializers/application_settings.rb
@@ -1,6 +1,10 @@
 # Loads non-sensitive application configuration from config/settings.yml and makes it available from Rails.configuration.settings
 Rails.application.configure do
-  config_data = YAML.load_file(Rails.root.join("config", "settings.yml"))
+  # config_data = YAML.load_file(Rails.root.join("config", "settings.yml"))
+  path = Rails.root.join("config", "settings.yml")
+  template = ERB.new(File.read(path))
+  processed = template.result(binding)
+  config_data = YAML.load(processed)
 
   config.settings = ActiveSupport::OrderedOptions.new
   config_data[Rails.env].each do |key, value|

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -9,6 +9,15 @@ defaults: &defaults
     cache_source: testlibnd-wse-honeycomb-pprd
     #cache_source: honeycomb-media-wse-library-nd-edu
 
+from_env: &from_env
+  wowza:
+    host: <%= ENV["WOWZA_HOST"] %>
+    port: <%= ENV["WOWZA_PORT"] %>
+    application: <%= ENV["WOWZA_APPLICATION"] %>
+    instance: <%= ENV["WOWZA_INSTANCE"] %>
+    cache_source_prefix: <%= ENV["WOWZA_CACHE_PREFIX"] %>
+    cache_source: <%= ENV["WOWZA_CACHE_SOURCE"] %>
+
 local: &local
   <<: *defaults
 
@@ -22,21 +31,7 @@ test:
   <<: *local
 
 pre_production:
-  <<: *deploy
-  wowza:
-    host: wowza.library.nd.edu
-    port: 443
-    application: buzz_wow
-    instance: _definst_
-    cache_source_prefix: amazons3
-    cache_source: testlibnd-wse-honeycomb-pprd
+  <<: *from_env
 
 production:
-  <<: *deploy
-  wowza:
-    host: wowza.library.nd.edu
-    port: 443
-    application: buzz_wow
-    instance: _definst_
-    cache_source_prefix: amazons3
-    cache_source: honeycomb-media-wse-library-nd-edu
+  <<: *from_env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,36 @@
+version: '3.4'
+
+services:
+  rails:
+    image: rails
+    build:
+      context: .
+      dockerfile: docker/Dockerfile
+    ports:
+      - 80:80
+    environment:
+      SSL: "false"
+      DEFAULT_URL_HOST: localhost
+      DEFAULT_URL_PROTOCOL: http
+      RAILS_ENV: production
+      RAILS_LOG_TO_STDOUT: "true"
+      RAILS_LOG_AUTOFLUSH: "true"
+      RAILS_LOG_LEVEL: DEBUG
+      # Do not use this value in actual production env
+      RAILS_SECRET_KEY_BASE: e08359113980fceb3b62152286866deac83789900db39acd16712910259d904089a53ebebf614db39844ddd467f004ae426424095083b447d9173c0ee6041de2
+      RDS_HOSTNAME: postgres
+      RDS_USERNAME: postgres
+      RDS_PASSWORD: p0stgr3s
+      RDS_DB_NAME: postgres
+      RDS_PORT: 5432
+      WOWZA_HOST: wowza.library.nd.edu
+      WOWZA_PORT: 443
+      WOWZA_APPLICATION: buzz_wow
+      WOWZA_INSTANCE: _definst_
+      WOWZA_CACHE_PREFIX: amazons3
+      WOWZA_CACHE_SOURCE: testlibnd-wse-honeycomb-pprd
+  postgres:
+    image: postgres:9.5.4
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: p0stgr3s

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,15 +3,6 @@ FROM ruby:2.4.4
 RUN apt-get update -qq && apt-get install -y build-essential
 RUN apt-get install -y nginx
 
-# Install chamber to get secrets from parameter store
-RUN curl https://github.com/segmentio/chamber/releases/download/v2.2.0/chamber_v2.2.0_amd64.deb --output chamber.deb -L
-RUN dpkg -i chamber.deb
-# We are just using the account's default ssm key to encrypt the values
-# If this changes, we'll need to override this alias
-ENV CHAMBER_KMS_KEY_ALIAS=aws/ssm
-ARG DEFAULT_ENV_SSM_PATH="all/buzz/prep"
-ENV ENV_SSM_PATH=$DEFAULT_ENV_SSM_PATH
-
 # Continue to build in home/app
 ENV APP_HOME /home/app/buzz
 RUN mkdir -p $APP_HOME
@@ -33,9 +24,9 @@ RUN rm /etc/nginx/sites-enabled/default
 COPY . $APP_HOME
 WORKDIR $APP_HOME
 
-#ENV RAILS_ENV=production
+COPY docker/database.yml $APP_HOME/config/database.yml
 
-RUN chmod u+x docker/entry.sh docker/start_services.sh
+RUN chmod u+x docker/start_services.sh
 # ENTRYPOINT ["bash", "docker/entry.sh"]
 # By default, start the required services
 CMD docker/start_services.sh

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,34 +1,14 @@
-# Running in development
-To run this locally, from the root directory:
-```bash
-docker build . -f docker/Dockerfile -t buzz
-docker run -p 80:80 --env PORT=80 \
-  --env AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
-  --env AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \
-  --env AWS_SECURITY_TOKEN=$AWS_SECURITY_TOKEN \
-  --env AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN \
-  --env AWS_REGION=$AWS_REGION \
-  --env RAILS_LOG_TO_STDOUT=true \
-  -it buzz
-```
+# Running in Docker
 
-Note: The if you change the PORT env, you will need to match the port in the -p option above
+This project includes a docker-compose configuration for testing how this project will be run in ECS.
+
+```bash
+docker-compose up
+docker-compose exec rails bundle exec rake db:schema:load
+```
 
 ## Running Integration Tests
+
 ```bash
 newman run spec/postman/spec.json -e spec/postman/local_env.json
-```
-
-# Running in production
-In production, the application's expected environment key/value pairs will be retrieved from SSM at the given ENV_SSM_PATH, while the AWS environment keys will be taken care of by ECS. Below is a simulated example of how this will be run when deployed as an ECS Task.
-```bash
-docker run -p 80:80 --env PORT=80 \
-  --env AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
-  --env AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \
-  --env AWS_SECURITY_TOKEN=$AWS_SECURITY_TOKEN \
-  --env AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN \
-  --env AWS_REGION=$AWS_REGION \
-  --env ENV_SSM_PATH=all/buzz/production \
-  --env RAILS_LOG_TO_STDOUT=true \
-  -it buzz
 ```

--- a/docker/database.yml
+++ b/docker/database.yml
@@ -1,0 +1,22 @@
+pg_settings: &pg_settings
+  adapter: postgresql
+  encoding: utf8
+  reconnect: true
+  pool: 5
+
+from_env: &from_env
+  <<: *pg_settings
+  username: <%= ENV["RDS_USERNAME"] %>
+  password: <%= ENV["RDS_PASSWORD"] %>
+  host:     <%= ENV["RDS_HOSTNAME"] %>
+  database: <%= ENV["RDS_DB_NAME"] %>
+  port:     <%= ENV["RDS_PORT"] %>
+
+development:
+  <<: *from_env
+
+pre_production:
+  <<: *from_env
+
+production:
+  <<: *from_env

--- a/docker/entry.sh
+++ b/docker/entry.sh
@@ -1,2 +1,0 @@
-echo Mapping SSM path "$ENV_SSM_PATH" to my environment.
-# exec chamber exec $ENV_SSM_PATH -- "$@"


### PR DESCRIPTION
In order for the API to point consumers back to the deployed host that's
generating the response, changed used hostname to be configurable via
env. Also enabled configuring wowza settings through env. Added a
docker-compose to more easily test this on a dev host.