### PR TITLE
Add rails migration entry

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,8 +25,7 @@ COPY . $APP_HOME
 WORKDIR $APP_HOME
 
 COPY docker/database.yml $APP_HOME/config/database.yml
+COPY docker/rails_entry.sh $APP_HOME/rails_entry.sh
+COPY docker/rails_migrate.sh $APP_HOME/rails_migrate.sh
 
-RUN chmod u+x docker/start_services.sh
-# ENTRYPOINT ["bash", "docker/entry.sh"]
-# By default, start the required services
-CMD docker/start_services.sh
+ENTRYPOINT ["bash", "rails_entry.sh"]

--- a/docker/rails_entry.sh
+++ b/docker/rails_entry.sh
@@ -1,3 +1,7 @@
+#!/bin/bash
+
+if ! docker/wait-for-it.sh -t 120 ${DB_HOSTNAME}:5432; then exit 1; fi
+
 # Runs nginx + puma services
 service nginx start
 bundle exec puma -b "unix://${APP_HOME}/shared/sockets/puma.sock"

--- a/docker/rails_migrate.sh
+++ b/docker/rails_migrate.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+if ! docker/wait-for-it.sh -t 120 ${DB_HOSTNAME}:5432; then exit 1; fi
+
+echo Running container in "$PWD" with the following command: "$@"
+exec "$@"

--- a/docker/wait-for-it.sh
+++ b/docker/wait-for-it.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+#   Use this script to test if a given TCP host/port are available
+
+cmdname=$(basename $0)
+
+echoerr() { if [[ $QUIET -ne 1 ]]; then echo "$@" 1>&2; fi }
+
+usage()
+{
+    cat << USAGE >&2
+Usage:
+    $cmdname host:port [-s] [-t timeout] [-- command args]
+    -h HOST | --host=HOST       Host or IP under test
+    -p PORT | --port=PORT       TCP port under test
+                                Alternatively, you specify the host and port as host:port
+    -s | --strict               Only execute subcommand if the test succeeds
+    -q | --quiet                Don't output any status messages
+    -t TIMEOUT | --timeout=TIMEOUT
+                                Timeout in seconds, zero for no timeout
+    -- COMMAND ARGS             Execute command with args after the test finishes
+USAGE
+    exit 1
+}
+
+wait_for()
+{
+    if [[ $TIMEOUT -gt 0 ]]; then
+        echoerr "$cmdname: waiting $TIMEOUT seconds for $HOST:$PORT"
+    else
+        echoerr "$cmdname: waiting for $HOST:$PORT without a timeout"
+    fi
+    start_ts=$(date +%s)
+    while :
+    do
+        if [[ $ISBUSY -eq 1 ]]; then
+            nc -z $HOST $PORT
+            result=$?
+        else
+            (echo > /dev/tcp/$HOST/$PORT) >/dev/null 2>&1
+            result=$?
+        fi
+        if [[ $result -eq 0 ]]; then
+            end_ts=$(date +%s)
+            echoerr "$cmdname: $HOST:$PORT is available after $((end_ts - start_ts)) seconds"
+            break
+        fi
+        sleep 1
+    done
+    return $result
+}
+
+wait_for_wrapper()
+{
+    # In order to support SIGINT during timeout: http://unix.stackexchange.com/a/57692
+    if [[ $QUIET -eq 1 ]]; then
+        timeout $BUSYTIMEFLAG $TIMEOUT $0 --quiet --child --host=$HOST --port=$PORT --timeout=$TIMEOUT &
+    else
+        timeout $BUSYTIMEFLAG $TIMEOUT $0 --child --host=$HOST --port=$PORT --timeout=$TIMEOUT &
+    fi
+    PID=$!
+    trap "kill -INT -$PID" INT
+    wait $PID
+    RESULT=$?
+    if [[ $RESULT -ne 0 ]]; then
+        echoerr "$cmdname: timeout occurred after waiting $TIMEOUT seconds for $HOST:$PORT"
+    fi
+    return $RESULT
+}
+
+# process arguments
+while [[ $# -gt 0 ]]
+do
+    case "$1" in
+        *:* )
+        hostport=(${1//:/ })
+        HOST=${hostport[0]}
+        PORT=${hostport[1]}
+        shift 1
+        ;;
+        --child)
+        CHILD=1
+        shift 1
+        ;;
+        -q | --quiet)
+        QUIET=1
+        shift 1
+        ;;
+        -s | --strict)
+        STRICT=1
+        shift 1
+        ;;
+        -h)
+        HOST="$2"
+        if [[ $HOST == "" ]]; then break; fi
+        shift 2
+        ;;
+        --host=*)
+        HOST="${1#*=}"
+        shift 1
+        ;;
+        -p)
+        PORT="$2"
+        if [[ $PORT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --port=*)
+        PORT="${1#*=}"
+        shift 1
+        ;;
+        -t)
+        TIMEOUT="$2"
+        if [[ $TIMEOUT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --timeout=*)
+        TIMEOUT="${1#*=}"
+        shift 1
+        ;;
+        --)
+        shift
+        CLI=("$@")
+        break
+        ;;
+        --help)
+        usage
+        ;;
+        *)
+        echoerr "Unknown argument: $1"
+        usage
+        ;;
+    esac
+done
+
+if [[ "$HOST" == "" || "$PORT" == "" ]]; then
+    echoerr "Error: you need to provide a host and port to test."
+    usage
+fi
+
+TIMEOUT=${TIMEOUT:-15}
+STRICT=${STRICT:-0}
+CHILD=${CHILD:-0}
+QUIET=${QUIET:-0}
+
+# check to see if timeout is from busybox?
+# check to see if timeout is from busybox?
+TIMEOUT_PATH=$(realpath $(which timeout))
+if [[ $TIMEOUT_PATH =~ "busybox" ]]; then
+        ISBUSY=1
+        BUSYTIMEFLAG="-t"
+else
+        ISBUSY=0
+        BUSYTIMEFLAG=""
+fi
+
+if [[ $CHILD -gt 0 ]]; then
+    wait_for
+    RESULT=$?
+    exit $RESULT
+else
+    if [[ $TIMEOUT -gt 0 ]]; then
+        wait_for_wrapper
+        RESULT=$?
+    else
+        wait_for
+        RESULT=$?
+    fi
+fi
+
+if [[ $CLI != "" ]]; then
+    if [[ $RESULT -ne 0 && $STRICT -eq 1 ]]; then
+        echoerr "$cmdname: strict mode, refusing to execute subprocess"
+        exit $RESULT
+    fi
+    exec "${CLI[@]}"
+else
+    exit $RESULT
+fi

--- a/spec/postman/local_env.json
+++ b/spec/postman/local_env.json
@@ -3,13 +3,7 @@
   "values": [
     {
       "key": "app-host",
-      "value": "localhost",
-      "type": "text",
-      "enabled": true
-    },
-    {
-      "key": "host-protocol",
-      "value": "http",
+      "value": "http://localhost",
       "type": "text",
       "enabled": true
     }

--- a/spec/postman/spec.json
+++ b/spec/postman/spec.json
@@ -42,9 +42,9 @@
 					"raw": "{\n  \"file_path\": \"testing/sample1.mp4\",\n  \"media_type\": \"video\"\n}"
 				},
 				"url": {
-					"raw": "{{host-protocol}}://{{app-host}}/v1/media_files",
+					"raw": "{{app-host}}/v1/media_files",
 					"host": [
-						"{{host-protocol}}://{{app-host}}"
+						"{{app-host}}"
 					],
 					"path": [
 						"v1",
@@ -86,9 +86,9 @@
 					"raw": "{\n  \"file_path\": \"testing/sample1.mp4\",\n  \"media_type\": \"video\"\n}"
 				},
 				"url": {
-					"raw": "{{host-protocol}}://{{app-host}}/v1/media_files/{{create_video_id}}",
+					"raw": "{{app-host}}/v1/media_files/{{create_video_id}}",
 					"host": [
-						"{{host-protocol}}://{{app-host}}"
+						"{{app-host}}"
 					],
 					"path": [
 						"v1",
@@ -139,9 +139,9 @@
 					"raw": "{\n  \"file_path\": \"big_full.mov\",\n  \"media_type\": \"audio\",\n  \"thumbnail_url\": \"testurl\"\n}"
 				},
 				"url": {
-					"raw": "{{host-protocol}}://{{app-host}}/v1/media_files/{{create_video_id}}",
+					"raw": "{{app-host}}/v1/media_files/{{create_video_id}}",
 					"host": [
-						"{{host-protocol}}://{{app-host}}"
+						"{{app-host}}"
 					],
 					"path": [
 						"v1",
@@ -189,9 +189,9 @@
 					"raw": "{\n  \"application\": \"honeycomb\",\n  \"file_path\": \"https://s3.amazonaws.com/honeycomb-media-dev.library.nd.edu/videos/videos/000/010/897/original/sample1.mp4\",\n  \"media_type\": \"audio\"\n}"
 				},
 				"url": {
-					"raw": "{{host-protocol}}://{{app-host}}/v1/media_files",
+					"raw": "{{app-host}}/v1/media_files",
 					"host": [
-						"{{host-protocol}}://{{app-host}}"
+						"{{app-host}}"
 					],
 					"path": [
 						"v1",
@@ -233,9 +233,9 @@
 					"raw": "{\n  \"file_path\": \"big_full.mp3\",\n  \"media_type\": \"audio\"\n}"
 				},
 				"url": {
-					"raw": "{{host-protocol}}://{{app-host}}/v1/media_files/{{create_audio_id}}",
+					"raw": "{{app-host}}/v1/media_files/{{create_audio_id}}",
 					"host": [
-						"{{host-protocol}}://{{app-host}}"
+						"{{app-host}}"
 					],
 					"path": [
 						"v1",
@@ -286,9 +286,9 @@
 					"raw": "{\n  \"file_path\": \"big_full.mov\",\n  \"media_type\": \"audio\",\n  \"thumbnail_url\": \"testurl\"\n}"
 				},
 				"url": {
-					"raw": "{{host-protocol}}://{{app-host}}/v1/media_files/{{create_audio_id}}",
+					"raw": "{{app-host}}/v1/media_files/{{create_audio_id}}",
 					"host": [
-						"{{host-protocol}}://{{app-host}}"
+						"{{app-host}}"
 					],
 					"path": [
 						"v1",


### PR DESCRIPTION
This adds an entry point for doing rails migrations. This is similar to
the entry point for the rails service, except it does not need to start
rails or nginx, so made sense to separate these out.

Additional changes:
- Changed the start services script to be named rails_entry.sh and use
a wait for db line to match how we're doing other services
- Simplified required newman params. Since we require https, seemed
overkill to require this as a param